### PR TITLE
feat(sdk): added support for semver matching when getting resources f…

### DIFF
--- a/.changeset/calm-fishes-juggle.md
+++ b/.changeset/calm-fishes-juggle.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/sdk": patch
+---
+
+feat(sdk): added support for semver matching when getting resources f…

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "devDependencies": {
     "@types/fs-extra": "^11.0.4",
     "@types/node": "^20.14.10",
+    "@types/semver": "^7.5.8",
     "prettier": "^3.3.3",
     "tsup": "^8.1.0",
     "typescript": "^5.5.3",
@@ -45,6 +46,7 @@
     "@changesets/cli": "^2.27.7",
     "fs-extra": "^11.2.0",
     "glob": "^11.0.0",
-    "gray-matter": "^4.0.3"
+    "gray-matter": "^4.0.3",
+    "semver": "7.6.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       gray-matter:
         specifier: ^4.0.3
         version: 4.0.3
+      semver:
+        specifier: 7.6.3
+        version: 7.6.3
     devDependencies:
       '@types/fs-extra':
         specifier: ^11.0.4
@@ -27,6 +30,9 @@ importers:
       '@types/node':
         specifier: ^20.14.10
         version: 20.14.10
+      '@types/semver':
+        specifier: ^7.5.8
+        version: 7.5.8
       prettier:
         specifier: ^3.3.3
         version: 3.3.3

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,7 @@ export default (path: string) => {
     /**
      * Returns an events from EventCatalog
      * @param id - The id of the event to retrieve
-     * @param version - Optional id of the version to get
+     * @param version - Optional id of the version to get (supports semver)
      * @returns
      */
     getEvent: getEvent(join(path, 'events')),
@@ -88,7 +88,7 @@ export default (path: string) => {
     /**
      * Returns a command from EventCatalog
      * @param id - The id of the command to retrieve
-     * @param version - Optional id of the version to get
+     * @param version - Optional id of the version to get (supports semver)
      * @returns
      */
     getCommand: getCommand(join(path, 'commands')),
@@ -153,7 +153,7 @@ export default (path: string) => {
     /**
      * Returns a service from EventCatalog
      * @param id - The id of the service to retrieve
-     * @param version - Optional id of the version to get
+     * @param version - Optional id of the version to get (supports semver)
      * @returns
      */
     getService: getService(join(path, 'services')),
@@ -202,7 +202,7 @@ export default (path: string) => {
     /**
      * Returns a domain from EventCatalog
      * @param id - The id of the domain to retrieve
-     * @param version - Optional id of the version to get
+     * @param version - Optional id of the version to get (supports semver)
      * @returns
      */
     getDomain: getDomain(join(path, 'domains')),

--- a/src/test/services.test.ts
+++ b/src/test/services.test.ts
@@ -99,6 +99,36 @@ describe('Services SDK', () => {
       });
     });
 
+    it('returns the latest version of the service when `latest` is passed as the version', async () => {
+      await writeService({
+        id: 'InventoryService',
+        name: 'Inventory Service',
+        version: '0.0.1',
+        summary: 'Service tat handles the inventory',
+        markdown: '# Hello world',
+      });
+
+      await versionService('InventoryService');
+
+      await writeService({
+        id: 'InventoryService',
+        name: 'Inventory Service',
+        version: '1.0.0',
+        summary: 'Service tat handles the inventory',
+        markdown: '# Hello world',
+      });
+
+      const test = await getService('InventoryService', 'latest');
+
+      expect(test).toEqual({
+        id: 'InventoryService',
+        name: 'Inventory Service',
+        version: '1.0.0',
+        summary: 'Service tat handles the inventory',
+        markdown: '# Hello world',
+      });
+    });
+
     it('throws an error if the service is not found', async () => {
       await expect(getService('PaymentService')).rejects.toThrowError('No service found for the given id: PaymentService');
     });


### PR DESCRIPTION
Added support for getDomain, getService, getCommand and getEvent to support semver options in the version query.

e.g `getService('my-service', 'latest')` returns the latest version of resource.