### PR TITLE
feat(sdk): adding team and user sdk functions

### DIFF
--- a/.changeset/popular-poets-tease.md
+++ b/.changeset/popular-poets-tease.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/sdk": minor
+---
+
+feat(sdk): adding team and user sdk functions

--- a/src/docs.ts
+++ b/src/docs.ts
@@ -31,3 +31,5 @@ export * from './events';
 export * from './commands';
 export * from './queries';
 export * from './channels';
+export * from './teams';
+export * from './users';

--- a/src/index.ts
+++ b/src/index.ts
@@ -698,7 +698,7 @@ export default (path: string) => {
     /**
      * Returns a user from EventCatalog
      * @param id - The id of the user to retrieve
-     * @returns Domain|Undefined
+     * @returns User|Undefined
      */
     getUser: getUser(join(path, 'users')),
     /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,6 +72,20 @@ import {
   addMessageToChannel,
 } from './channels';
 
+import {
+  writeTeam,
+  getTeam,
+  getTeams,
+  rmTeamById,
+} from './teams';
+
+import {
+  writeUser,
+  getUser,
+  getUsers,
+  rmUserById,
+} from './users';
+
 /**
  * Init the SDK for EventCatalog
  *
@@ -645,5 +659,71 @@ export default (path: string) => {
      * @returns
      */
     addServiceToDomain: addServiceToDomain(join(path, 'domains')),
+
+    /**
+     * ================================
+     *            Teams
+     * ================================
+     */
+    /**
+     * Adds a team to EventCatalog
+     *
+     * @param team - The team to write
+     * @param options - Optional options to write the team
+     *
+     */
+    writeTeam: writeTeam(join(path, 'teams')),
+    /**
+     * Returns a team from EventCatalog
+     * @param id - The id of the team to retrieve
+     * @returns Team|Undefined
+     */
+    getTeam: getTeam(join(path, 'teams')),
+    /**
+     * Returns all teams from EventCatalog
+     * @returns Team[]|Undefined
+     */
+    getTeams: getTeams(join(path)),
+    /**
+     * Remove a team by the team id
+     *
+     * @param id - The id of the team you want to remove
+     *
+     */
+    rmTeamById: rmTeamById(join(path, 'teams')),
+
+
+    /**
+     * ================================
+     *            Users
+     * ================================
+     */
+    /**
+     * Adds a user to EventCatalog
+     *
+     * @param user - The user to write
+     * @param options - Optional options to write the user
+     *
+     */
+    writeUser: writeUser(join(path, 'users')),
+    /**
+     * Returns a user from EventCatalog
+     * @param id - The id of the user to retrieve
+     * @returns Domain|Undefined
+     */
+    getUser: getUser(join(path, 'users')),
+    /**
+     * Returns all user from EventCatalog
+     * @returns User[]|Undefined
+     */
+    getUsers: getUsers(join(path)),
+    /**
+     * Remove a user by the user id
+     *
+     * @param id - The id of the user you want to remove
+     *
+     */
+    rmUserById: rmUserById(join(path, 'users')),
+
   };
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,19 +72,9 @@ import {
   addMessageToChannel,
 } from './channels';
 
-import {
-  writeTeam,
-  getTeam,
-  getTeams,
-  rmTeamById,
-} from './teams';
+import { writeTeam, getTeam, getTeams, rmTeamById } from './teams';
 
-import {
-  writeUser,
-  getUser,
-  getUsers,
-  rmUserById,
-} from './users';
+import { writeUser, getUser, getUsers, rmUserById } from './users';
 
 /**
  * Init the SDK for EventCatalog
@@ -692,7 +682,6 @@ export default (path: string) => {
      */
     rmTeamById: rmTeamById(join(path, 'teams')),
 
-
     /**
      * ================================
      *            Users
@@ -724,6 +713,5 @@ export default (path: string) => {
      *
      */
     rmUserById: rmUserById(join(path, 'users')),
-
   };
 };

--- a/src/teams.ts
+++ b/src/teams.ts
@@ -1,0 +1,139 @@
+import fs from 'node:fs/promises';
+import { join } from 'node:path';
+import type { Team } from './types';
+import matter from 'gray-matter';
+import { getFiles } from './internal/utils';
+
+/**
+ * Returns a team from EventCatalog.
+ *
+ *
+ * @example
+ * ```ts
+ * import utils from '@eventcatalog/utils';
+ *
+ * const { getTeam } = utils('/path/to/eventcatalog');
+ *
+ * // Gets the team with the given id
+ * const team = await getTeam('eventcatalog-core-team');
+ *
+ * ```
+ */
+export const getTeam =
+  (catalogDir: string) =>
+  async (id: string): Promise<Team | undefined> => {
+    const files = await getFiles(`${catalogDir}/${id}.md`);
+
+    if (files.length == 0) return undefined;
+    const file = files[0];
+
+    const { data, content } = matter.read(file);
+    return {
+      ...data,
+      id: data.id,
+      name: data.name,
+      markdown: content.trim(),
+    } as Team;
+
+  }
+
+/**
+ * Returns all teams from EventCatalog.
+ *
+ * @example
+ * ```ts
+ * import utils from '@eventcatalog/utils';
+ *
+ * const { getTeams } = utils('/path/to/eventcatalog');
+ *
+ * // Gets all teams from the catalog
+ * const channels = await getTeams();
+ *
+ * ```
+ */
+export const getTeams =
+  (catalogDir: string) =>
+  async (options?: { }): Promise<Team[]> => {
+    const files = await getFiles(`${catalogDir}/teams/*.md`);
+    if (files.length === 0) return [];
+
+    return files.map((file) => {
+      const { data, content } = matter.read(file);
+      return {
+        ...data,
+        id: data.id,
+        name: data.name,
+        markdown: content.trim(),
+      } as Team;
+    });
+  }
+
+/**
+ * Write a team to EventCatalog.
+ *
+ * @example
+ * ```ts
+ * import utils from '@eventcatalog/utils';
+ *
+ * const { writeTeam } = utils('/path/to/eventcatalog');
+ *
+ * // Write a team to the catalog
+ * // team would be written to teams/EventCatalogCoreTeam
+ * await writeTeam({
+ *   id: 'eventcatalog-core-team',
+ *   name: 'EventCatalogCoreTeam',
+ *   members: ['dboyne', 'asmith', 'msmith'],
+ *   email: 'test@test.com',
+ *   slackDirectMessageUrl: https://yourteam.slack.com/channels/boyney123
+ * });
+ *
+ * // Write a channel to the catalog and override the existing content (if there is any)
+ * await writeTeam({
+ *   id: 'eventcatalog-core-team',
+ *   name: 'EventCatalogCoreTeam',
+ *   members: ['dboyne', 'asmith', 'msmith'],
+ *   email: 'test@test.com',
+ *   slackDirectMessageUrl: https://yourteam.slack.com/channels/boyney123
+ * }, { override: true });
+ *
+ * ```
+ */
+export const writeTeam =
+  (catalogDir: string) =>
+  async (team: Team, options: { override?: boolean} = { }) => {
+    const resource: Team = { ...team };
+
+    // Get the path
+    const currentTeam = await getTeam(catalogDir)(resource.id);
+    const exists = currentTeam !== undefined;
+
+    if (exists && !options.override) {
+      throw new Error(`Failed to write ${resource.id} (team) as it already exists`);
+    }
+
+    const { markdown, ...frontmatter } = resource;
+
+    const document = matter.stringify(markdown, frontmatter);
+    await fs.mkdir(join(catalogDir, ''), { recursive: true });
+    await fs.writeFile(join(catalogDir, '', `${resource.id}.md`), document);
+
+  };
+
+
+/**
+ * Delete a team by it's id.
+ *
+ * @example
+ * ```ts
+ * import utils from '@eventcatalog/utils';
+ *
+ * const { rmTeamById } = utils('/path/to/eventcatalog');
+ *
+ * // deletes the EventCatalogCoreTeam team
+ * await rmTeamById('eventcatalog-core-team');
+ *
+ * ```
+ */
+export const rmTeamById = (catalogDir: string) => async (id: string) => {
+  await fs.rm(join(catalogDir, `${id}.md`), { recursive: true });
+};

--- a/src/teams.ts
+++ b/src/teams.ts
@@ -86,7 +86,7 @@ export const getTeams =
  *   slackDirectMessageUrl: https://yourteam.slack.com/channels/boyney123
  * });
  *
- * // Write a channel to the catalog and override the existing content (if there is any)
+ * // Write a team to the catalog and override the existing content (if there is any)
  * await writeTeam({
  *   id: 'eventcatalog-core-team',
  *   name: 'EventCatalogCoreTeam',

--- a/src/teams.ts
+++ b/src/teams.ts
@@ -34,8 +34,7 @@ export const getTeam =
       name: data.name,
       markdown: content.trim(),
     } as Team;
-
-  }
+  };
 
 /**
  * Returns all teams from EventCatalog.
@@ -53,7 +52,7 @@ export const getTeam =
  */
 export const getTeams =
   (catalogDir: string) =>
-  async (options?: { }): Promise<Team[]> => {
+  async (options?: {}): Promise<Team[]> => {
     const files = await getFiles(`${catalogDir}/teams/*.md`);
     if (files.length === 0) return [];
 
@@ -66,7 +65,7 @@ export const getTeams =
         markdown: content.trim(),
       } as Team;
     });
-  }
+  };
 
 /**
  * Write a team to EventCatalog.
@@ -100,7 +99,7 @@ export const getTeams =
  */
 export const writeTeam =
   (catalogDir: string) =>
-  async (team: Team, options: { override?: boolean} = { }) => {
+  async (team: Team, options: { override?: boolean } = {}) => {
     const resource: Team = { ...team };
 
     // Get the path
@@ -116,9 +115,7 @@ export const writeTeam =
     const document = matter.stringify(markdown, frontmatter);
     await fs.mkdir(join(catalogDir, ''), { recursive: true });
     await fs.writeFile(join(catalogDir, '', `${resource.id}.md`), document);
-
   };
-
 
 /**
  * Delete a team by it's id.

--- a/src/test/teams.test.ts
+++ b/src/test/teams.test.ts
@@ -107,7 +107,7 @@ describe('Teams SDK', () => {
       ).rejects.toThrowError('Failed to write eventcatalog-core-team (team) as it already exists');
     });
 
-    it('overrides the domain when trying to write an domain that already exists and override is true', async () => {
+    it('overrides the team when trying to write an team that already exists and override is true', async () => {
       await writeTeam({
         id: 'eventcatalog-core-team',
         name: 'Eventcatalog Core Team',

--- a/src/test/teams.test.ts
+++ b/src/test/teams.test.ts
@@ -1,0 +1,157 @@
+// teams.test.js
+import { expect, it, describe, beforeEach, afterEach } from 'vitest';
+import utils from '../index';
+import path from 'node:path';
+import fs from 'node:fs';
+
+const CATALOG_PATH = path.join(__dirname, 'catalog-teams');
+
+const {
+  writeTeam,
+  getTeam,
+  getTeams,
+  rmTeamById,
+} = utils(CATALOG_PATH);
+
+// clean the catalog before each test
+beforeEach(() => {
+  fs.rmSync(CATALOG_PATH, { recursive: true, force: true });
+  fs.mkdirSync(CATALOG_PATH, { recursive: true });
+});
+
+afterEach(() => {
+  fs.rmSync(CATALOG_PATH, { recursive: true, force: true });
+});
+
+describe('Teams SDK', () => {
+  describe('getTeam', () => {
+    it('returns the given team by id from EventCatalog,', async () => {
+      await writeTeam({
+        id: 'eventcatalog-core-team',
+        name: 'Eventcatalog Core Team',
+        markdown: 'This is the core team for Eventcatalog',
+      });
+
+      const test = await getTeam('eventcatalog-core-team');
+
+      expect(test).toEqual({
+        id: 'eventcatalog-core-team',
+        name: 'Eventcatalog Core Team',
+        markdown: 'This is the core team for Eventcatalog',
+      });
+    });
+
+    it('returns undefined when the team is not found', async () => {
+      await expect(await getTeam('unknown-team')).toEqual(undefined);
+    });
+
+  });
+
+  describe('getTeams', () => {
+    it('returns all the teams in the catalog,', async () => {
+      await writeTeam({
+        id: 'eventcatalog-core-team',
+        name: 'Eventcatalog Core Team',
+        markdown: 'This is the core team for Eventcatalog',
+      });
+
+      await writeTeam({
+        id: 'eventcatalog-second-team',
+        name: 'Eventcatalog Second Team',
+        markdown: 'This is the second team for Eventcatalog',
+      });
+
+      const teams = await getTeams();
+
+      expect(teams).toEqual([
+        {
+          id: 'eventcatalog-second-team',
+          name: 'Eventcatalog Second Team',
+          markdown: 'This is the second team for Eventcatalog',
+        },
+        {
+          id: 'eventcatalog-core-team',
+          name: 'Eventcatalog Core Team',
+          markdown: 'This is the core team for Eventcatalog',
+        },
+      ]);
+    });
+
+  });
+
+  
+  describe('writeTeam', () => {
+    it('writes the given team to EventCatalog and assumes the path if one if not given', async () => {
+      await writeTeam({
+        id: 'eventcatalog-core-team',
+        name: 'Eventcatalog Core Team',
+        markdown: 'This is the core team for Eventcatalog',
+      });
+
+      const team = await getTeam('eventcatalog-core-team');
+
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'teams', 'eventcatalog-core-team.md'))).toBe(true);
+
+      expect(team).toEqual({
+        id: 'eventcatalog-core-team',
+        name: 'Eventcatalog Core Team',
+        markdown: 'This is the core team for Eventcatalog',
+      });
+    });
+
+    it('throws an error when trying to write a team that already exists', async () => {
+      await writeTeam({
+        id: 'eventcatalog-core-team',
+        name: 'Eventcatalog Core Team',
+        markdown: 'This is the core team for Eventcatalog',
+      });
+
+      await expect(
+        writeTeam({
+          id: 'eventcatalog-core-team',
+          name: 'Eventcatalog Core Team',
+          markdown: 'This is the core team for Eventcatalog',
+        })
+      ).rejects.toThrowError('Failed to write eventcatalog-core-team (team) as it already exists');
+    });
+
+    it('overrides the domain when trying to write an domain that already exists and override is true', async () => {
+      await writeTeam({
+        id: 'eventcatalog-core-team',
+        name: 'Eventcatalog Core Team',
+        markdown: 'This is the core team for Eventcatalog',
+      });
+
+      await writeTeam(
+        {
+          id: 'eventcatalog-core-team',
+          name: 'Eventcatalog Core Team Overridden',
+          markdown: 'This is the core team for Eventcatalog',
+        },
+        { override: true }
+      );
+
+      const team = await getTeam('eventcatalog-core-team');
+
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'teams', 'eventcatalog-core-team.md'))).toBe(true);
+      expect(team.name).toBe('Eventcatalog Core Team Overridden');
+    });
+
+  });
+
+  describe('rmTeamById', () => {
+    it('removes a team from eventcatalog by id', async () => {
+      await writeTeam({
+        id: 'eventcatalog-core-team',
+        name: 'Eventcatalog Core Team',
+        markdown: 'This is the core team for Eventcatalog',
+      });
+
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'teams', 'eventcatalog-core-team.md'))).toBe(true);
+
+      await rmTeamById('eventcatalog-core-team');
+
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'teams', 'eventcatalog-core-team.md'))).toBe(false);
+    });
+  });
+});

--- a/src/test/teams.test.ts
+++ b/src/test/teams.test.ts
@@ -6,12 +6,7 @@ import fs from 'node:fs';
 
 const CATALOG_PATH = path.join(__dirname, 'catalog-teams');
 
-const {
-  writeTeam,
-  getTeam,
-  getTeams,
-  rmTeamById,
-} = utils(CATALOG_PATH);
+const { writeTeam, getTeam, getTeams, rmTeamById } = utils(CATALOG_PATH);
 
 // clean the catalog before each test
 beforeEach(() => {
@@ -44,7 +39,6 @@ describe('Teams SDK', () => {
     it('returns undefined when the team is not found', async () => {
       await expect(await getTeam('unknown-team')).toEqual(undefined);
     });
-
   });
 
   describe('getTeams', () => {
@@ -76,10 +70,8 @@ describe('Teams SDK', () => {
         },
       ]);
     });
-
   });
 
-  
   describe('writeTeam', () => {
     it('writes the given team to EventCatalog and assumes the path if one if not given', async () => {
       await writeTeam({
@@ -136,7 +128,6 @@ describe('Teams SDK', () => {
       expect(fs.existsSync(path.join(CATALOG_PATH, 'teams', 'eventcatalog-core-team.md'))).toBe(true);
       expect(team.name).toBe('Eventcatalog Core Team Overridden');
     });
-
   });
 
   describe('rmTeamById', () => {

--- a/src/test/users.test.ts
+++ b/src/test/users.test.ts
@@ -107,7 +107,7 @@ describe('Users SDK', () => {
       ).rejects.toThrowError('Failed to write eventcatalog-core-user (user) as it already exists');
     });
 
-    it('overrides the domain when trying to write an domain that already exists and override is true', async () => {
+    it('overrides the user when trying to write an user that already exists and override is true', async () => {
       await writeUser({
         id: 'eventcatalog-core-user',
         name: 'Eventcatalog Core User',

--- a/src/test/users.test.ts
+++ b/src/test/users.test.ts
@@ -6,12 +6,7 @@ import fs from 'node:fs';
 
 const CATALOG_PATH = path.join(__dirname, 'catalog-users');
 
-const {
-  writeUser,
-  getUser,
-  getUsers,
-  rmUserById,
-} = utils(CATALOG_PATH);
+const { writeUser, getUser, getUsers, rmUserById } = utils(CATALOG_PATH);
 
 // clean the catalog before each test
 beforeEach(() => {
@@ -44,7 +39,6 @@ describe('Users SDK', () => {
     it('returns undefined when the user is not found', async () => {
       await expect(await getUser('unknown-user')).toEqual(undefined);
     });
-
   });
 
   describe('getUsers', () => {
@@ -76,10 +70,8 @@ describe('Users SDK', () => {
         },
       ]);
     });
-
   });
 
-  
   describe('writeUser', () => {
     it('writes the given user to EventCatalog and assumes the path if one if not given', async () => {
       await writeUser({
@@ -136,7 +128,6 @@ describe('Users SDK', () => {
       expect(fs.existsSync(path.join(CATALOG_PATH, 'users', 'eventcatalog-core-user.md'))).toBe(true);
       expect(user.name).toBe('Eventcatalog Core User Overridden');
     });
-
   });
 
   describe('rmUserById', () => {

--- a/src/test/users.test.ts
+++ b/src/test/users.test.ts
@@ -1,0 +1,157 @@
+// users.test.js
+import { expect, it, describe, beforeEach, afterEach } from 'vitest';
+import utils from '../index';
+import path from 'node:path';
+import fs from 'node:fs';
+
+const CATALOG_PATH = path.join(__dirname, 'catalog-users');
+
+const {
+  writeUser,
+  getUser,
+  getUsers,
+  rmUserById,
+} = utils(CATALOG_PATH);
+
+// clean the catalog before each test
+beforeEach(() => {
+  fs.rmSync(CATALOG_PATH, { recursive: true, force: true });
+  fs.mkdirSync(CATALOG_PATH, { recursive: true });
+});
+
+afterEach(() => {
+  fs.rmSync(CATALOG_PATH, { recursive: true, force: true });
+});
+
+describe('Users SDK', () => {
+  describe('getUser', () => {
+    it('returns the given user by id from EventCatalog,', async () => {
+      await writeUser({
+        id: 'eventcatalog-core-user',
+        name: 'Eventcatalog Core user',
+        markdown: 'This is the core user for Eventcatalog',
+      });
+
+      const test = await getUser('eventcatalog-core-user');
+
+      expect(test).toEqual({
+        id: 'eventcatalog-core-user',
+        name: 'Eventcatalog Core user',
+        markdown: 'This is the core user for Eventcatalog',
+      });
+    });
+
+    it('returns undefined when the user is not found', async () => {
+      await expect(await getUser('unknown-user')).toEqual(undefined);
+    });
+
+  });
+
+  describe('getUsers', () => {
+    it('returns all the users in the catalog,', async () => {
+      await writeUser({
+        id: 'eventcatalog-core-user',
+        name: 'Eventcatalog Core User',
+        markdown: 'This is the core user for Eventcatalog',
+      });
+
+      await writeUser({
+        id: 'eventcatalog-second-user',
+        name: 'Eventcatalog Second User',
+        markdown: 'This is the second user for Eventcatalog',
+      });
+
+      const users = await getUsers();
+
+      expect(users).toEqual([
+        {
+          id: 'eventcatalog-second-user',
+          name: 'Eventcatalog Second User',
+          markdown: 'This is the second user for Eventcatalog',
+        },
+        {
+          id: 'eventcatalog-core-user',
+          name: 'Eventcatalog Core User',
+          markdown: 'This is the core user for Eventcatalog',
+        },
+      ]);
+    });
+
+  });
+
+  
+  describe('writeUser', () => {
+    it('writes the given user to EventCatalog and assumes the path if one if not given', async () => {
+      await writeUser({
+        id: 'eventcatalog-core-user',
+        name: 'Eventcatalog Core User',
+        markdown: 'This is the core user for Eventcatalog',
+      });
+
+      const user = await getUser('eventcatalog-core-user');
+
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'users', 'eventcatalog-core-user.md'))).toBe(true);
+
+      expect(user).toEqual({
+        id: 'eventcatalog-core-user',
+        name: 'Eventcatalog Core User',
+        markdown: 'This is the core user for Eventcatalog',
+      });
+    });
+
+    it('throws an error when trying to write a user that already exists', async () => {
+      await writeUser({
+        id: 'eventcatalog-core-user',
+        name: 'Eventcatalog Core User',
+        markdown: 'This is the core user for Eventcatalog',
+      });
+
+      await expect(
+        writeUser({
+          id: 'eventcatalog-core-user',
+          name: 'Eventcatalog Core User',
+          markdown: 'This is the core user for Eventcatalog',
+        })
+      ).rejects.toThrowError('Failed to write eventcatalog-core-user (user) as it already exists');
+    });
+
+    it('overrides the domain when trying to write an domain that already exists and override is true', async () => {
+      await writeUser({
+        id: 'eventcatalog-core-user',
+        name: 'Eventcatalog Core User',
+        markdown: 'This is the core user for Eventcatalog',
+      });
+
+      await writeUser(
+        {
+          id: 'eventcatalog-core-user',
+          name: 'Eventcatalog Core User Overridden',
+          markdown: 'This is the core user for Eventcatalog',
+        },
+        { override: true }
+      );
+
+      const user = await getUser('eventcatalog-core-user');
+
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'users', 'eventcatalog-core-user.md'))).toBe(true);
+      expect(user.name).toBe('Eventcatalog Core User Overridden');
+    });
+
+  });
+
+  describe('rmUserById', () => {
+    it('removes a user from eventcatalog by id', async () => {
+      await writeUser({
+        id: 'eventcatalog-core-user',
+        name: 'Eventcatalog Core User',
+        markdown: 'This is the core user for Eventcatalog',
+      });
+
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'users', 'eventcatalog-core-user.md'))).toBe(true);
+
+      await rmUserById('eventcatalog-core-user');
+
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'users', 'eventcatalog-core-user.md'))).toBe(false);
+    });
+  });
+});

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -76,6 +76,7 @@ export interface Team {
   ownedCommands?: Command[];
   ownedServices?: Service[];
   ownedEvents?: Event[];
+  markdown: string;
 }
 
 export interface User {
@@ -90,6 +91,7 @@ export interface User {
   ownedEvents?: Event[];
   ownedCommands?: Command[];
   associatedTeams?: Team[];
+  markdown: string;
 }
 
 export interface Badge {

--- a/src/users.ts
+++ b/src/users.ts
@@ -88,7 +88,7 @@ export const getUsers =
  *   slackDirectMessageUrl: https://yourteam.slack.com/channels/boyney123
  * });
  *
- * // Write a channel to the catalog and override the existing content (if there is any)
+ * // Write a team to the catalog and override the existing content (if there is any)
  * await writeUser({
  *   id: 'eventcatalog-tech-lead',
  *   name: 'EventCatalog Tech Lead',

--- a/src/users.ts
+++ b/src/users.ts
@@ -34,8 +34,7 @@ export const getUser =
       name: data.name,
       markdown: content.trim(),
     } as User;
-
-  }
+  };
 
 /**
  * Returns all users from EventCatalog.
@@ -53,7 +52,7 @@ export const getUser =
  */
 export const getUsers =
   (catalogDir: string) =>
-  async (options?: { }): Promise<User[]> => {
+  async (options?: {}): Promise<User[]> => {
     const files = await getFiles(`${catalogDir}/users/*.md`);
     if (files.length === 0) return [];
 
@@ -66,7 +65,7 @@ export const getUsers =
         markdown: content.trim(),
       } as User;
     });
-  }
+  };
 
 /**
  * Write a user to EventCatalog.
@@ -98,7 +97,7 @@ export const getUsers =
  */
 export const writeUser =
   (catalogDir: string) =>
-  async (user: User, options: { override?: boolean} = { }) => {
+  async (user: User, options: { override?: boolean } = {}) => {
     const resource: User = { ...user };
 
     // Get the path
@@ -114,7 +113,6 @@ export const writeUser =
     const document = matter.stringify(markdown, frontmatter);
     await fs.mkdir(join(catalogDir, ''), { recursive: true });
     await fs.writeFile(join(catalogDir, '', `${resource.id}.md`), document);
-
   };
 
 /**

--- a/src/users.ts
+++ b/src/users.ts
@@ -32,6 +32,7 @@ export const getUser =
       ...data,
       id: data.id,
       name: data.name,
+      avatarUrl: data.avatarUrl,
       markdown: content.trim(),
     } as User;
   };
@@ -62,6 +63,7 @@ export const getUsers =
         ...data,
         id: data.id,
         name: data.name,
+        avatarUrl: data.avatarUrl,
         markdown: content.trim(),
       } as User;
     });
@@ -82,6 +84,7 @@ export const getUsers =
  *   id: 'eventcatalog-tech-lead',
  *   name: 'EventCatalog Tech Lead',
  *   email: 'test@test.com',
+ *   avatarUrl: 'https://pbs.twimg.com/profile_images/1262283153563140096/DYRDqKg6_400x400.png',
  *   slackDirectMessageUrl: https://yourteam.slack.com/channels/boyney123
  * });
  *
@@ -90,6 +93,7 @@ export const getUsers =
  *   id: 'eventcatalog-tech-lead',
  *   name: 'EventCatalog Tech Lead',
  *   email: 'test@test.com',
+ *   avatarUrl: 'https://pbs.twimg.com/profile_images/1262283153563140096/DYRDqKg6_400x400.png',
  *   slackDirectMessageUrl: https://yourteam.slack.com/channels/boyney123
  * }, { override: true });
  *

--- a/src/users.ts
+++ b/src/users.ts
@@ -1,0 +1,136 @@
+import fs from 'node:fs/promises';
+import { join } from 'node:path';
+import type { User } from './types';
+import matter from 'gray-matter';
+import { getFiles } from './internal/utils';
+
+/**
+ * Returns a user from EventCatalog.
+ *
+ *
+ * @example
+ * ```ts
+ * import utils from '@eventcatalog/utils';
+ *
+ * const { getUser } = utils('/path/to/eventcatalog');
+ *
+ * // Gets the user with the given id
+ * const user = await getUser('eventcatalog-core-user');
+ *
+ * ```
+ */
+export const getUser =
+  (catalogDir: string) =>
+  async (id: string): Promise<User | undefined> => {
+    const files = await getFiles(`${catalogDir}/${id}.md`);
+
+    if (files.length == 0) return undefined;
+    const file = files[0];
+
+    const { data, content } = matter.read(file);
+    return {
+      ...data,
+      id: data.id,
+      name: data.name,
+      markdown: content.trim(),
+    } as User;
+
+  }
+
+/**
+ * Returns all users from EventCatalog.
+ *
+ * @example
+ * ```ts
+ * import utils from '@eventcatalog/utils';
+ *
+ * const { getUsers } = utils('/path/to/eventcatalog');
+ *
+ * // Gets all users from the catalog
+ * const channels = await getUsers();
+ *
+ * ```
+ */
+export const getUsers =
+  (catalogDir: string) =>
+  async (options?: { }): Promise<User[]> => {
+    const files = await getFiles(`${catalogDir}/users/*.md`);
+    if (files.length === 0) return [];
+
+    return files.map((file) => {
+      const { data, content } = matter.read(file);
+      return {
+        ...data,
+        id: data.id,
+        name: data.name,
+        markdown: content.trim(),
+      } as User;
+    });
+  }
+
+/**
+ * Write a user to EventCatalog.
+ *
+ * @example
+ * ```ts
+ * import utils from '@eventcatalog/utils';
+ *
+ * const { writeUser } = utils('/path/to/eventcatalog');
+ *
+ * // Write a user to the catalog
+ * // user would be written to users/eventcatalog-tech-lead
+ * await writeUser({
+ *   id: 'eventcatalog-tech-lead',
+ *   name: 'EventCatalog Tech Lead',
+ *   email: 'test@test.com',
+ *   slackDirectMessageUrl: https://yourteam.slack.com/channels/boyney123
+ * });
+ *
+ * // Write a channel to the catalog and override the existing content (if there is any)
+ * await writeUser({
+ *   id: 'eventcatalog-tech-lead',
+ *   name: 'EventCatalog Tech Lead',
+ *   email: 'test@test.com',
+ *   slackDirectMessageUrl: https://yourteam.slack.com/channels/boyney123
+ * }, { override: true });
+ *
+ * ```
+ */
+export const writeUser =
+  (catalogDir: string) =>
+  async (user: User, options: { override?: boolean} = { }) => {
+    const resource: User = { ...user };
+
+    // Get the path
+    const currentUser = await getUser(catalogDir)(resource.id);
+    const exists = currentUser !== undefined;
+
+    if (exists && !options.override) {
+      throw new Error(`Failed to write ${resource.id} (user) as it already exists`);
+    }
+
+    const { markdown, ...frontmatter } = resource;
+
+    const document = matter.stringify(markdown, frontmatter);
+    await fs.mkdir(join(catalogDir, ''), { recursive: true });
+    await fs.writeFile(join(catalogDir, '', `${resource.id}.md`), document);
+
+  };
+
+/**
+ * Delete a user by it's id.
+ *
+ * @example
+ * ```ts
+ * import utils from '@eventcatalog/utils';
+ *
+ * const { rmUserById } = utils('/path/to/eventcatalog');
+ *
+ * // deletes the user with id eventcatalog-core-user
+ * await rmUserById('eventcatalog-core-user');
+ *
+ * ```
+ */
+export const rmUserById = (catalogDir: string) => async (id: string) => {
+  await fs.rm(join(catalogDir, `${id}.md`), { recursive: true });
+};


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to EventCatalog here: https://www.eventcatalog.dev/docs/contributing/overview

Happy contributing!

-->
This pull request introduces functionality for managing teams and users in the EventCatalog. The most important changes include adding new modules for teams and users, updating the SDK to include these new functionalities, and adding corresponding tests.

### New Functionality for Teams and Users:

* [`src/teams.ts`](diffhunk://#diff-ed82af20c26ef1c8a7ff2302eccc191048713b1c8826277fac1ca5f885ccc8d2R1-R139): Added functions to get, write, and remove teams from the EventCatalog. This includes `getTeam`, `getTeams`, `writeTeam`, and `rmTeamById`.
* [`src/users.ts`](diffhunk://#diff-e5913cca70de3baa9860b5af30dc3cc647849c63c76161f213cf7ec3bf2b464fR1-R136): Added functions to get, write, and remove users from the EventCatalog. This includes `getUser`, `getUsers`, `writeUser`, and `rmUserById`.

### SDK Updates:

* [`src/index.ts`](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R75-R88): Updated the SDK to include the new team and user functions. This includes importing the new functions and adding them to the SDK's exported methods. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R75-R88) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R662-R727)
