### PR TITLE
fix(sdk): issue getting resources in nested folder structures

### DIFF
--- a/.changeset/giant-brooms-happen.md
+++ b/.changeset/giant-brooms-happen.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/sdk": patch
+---
+
+fix(sdk): issue getting resources in nested folder structures

--- a/src/domains.ts
+++ b/src/domains.ts
@@ -55,7 +55,11 @@ export const getDomain =
 export const getDomains =
   (directory: string) =>
   async (options?: { latestOnly?: boolean }): Promise<Domain[]> =>
-    getResources(directory, { type: 'domains', ...options }) as Promise<Domain[]>;
+    getResources(directory, {
+      type: 'domains',
+      ignore: ['**/services/**', '**/events/**', '**/commands/**', '**/queries/**'],
+      ...options,
+    }) as Promise<Domain[]>;
 
 /**
  * Write a domain to EventCatalog.

--- a/src/internal/resources.ts
+++ b/src/internal/resources.ts
@@ -98,10 +98,10 @@ export const getResource = async (
 
 export const getResources = async (
   catalogDir: string,
-  { type, latestOnly = false }: { type: string; latestOnly?: boolean }
+  { type, latestOnly = false, ignore = [] }: { type: string; latestOnly?: boolean; ignore?: string[] }
 ): Promise<Resource[] | undefined> => {
-  const ignore = latestOnly ? `**/versioned/**` : '';
-  const files = await getFiles(`${catalogDir}/**/${type}/**/index.md`, ignore);
+  const ignoreList = latestOnly ? `**/versioned/**` : '';
+  const files = await getFiles(`${catalogDir}/**/${type}/**/index.md`, [ignoreList, ...ignore]);
   if (files.length === 0) return;
 
   return files.map((file) => {

--- a/src/internal/utils.ts
+++ b/src/internal/utils.ts
@@ -50,9 +50,10 @@ export const findFileById = async (catalogDir: string, id: string, version?: str
   }
 };
 
-export const getFiles = async (pattern: string, ignore: string = '') => {
+export const getFiles = async (pattern: string, ignore: string | string[] = '') => {
   try {
-    const files = await glob(pattern, { ignore: ['node_modules/**', ignore] });
+    const ignoreList = Array.isArray(ignore) ? ignore : [ignore];
+    const files = await glob(pattern, { ignore: ['node_modules/**', ...ignoreList] });
     return files;
   } catch (error) {
     throw new Error(`Error finding files: ${error}`);

--- a/src/services.ts
+++ b/src/services.ts
@@ -57,7 +57,11 @@ export const getService =
 export const getServices =
   (directory: string) =>
   async (options?: { latestOnly?: boolean }): Promise<Service[]> =>
-    getResources(directory, { type: 'services', ...options }) as Promise<Service[]>;
+    getResources(directory, {
+      type: 'services',
+      ignore: ['**/events/**', '**/commands/**', '**/queries/**'],
+      ...options,
+    }) as Promise<Service[]>;
 
 /**
  * Write a Service to EventCatalog.

--- a/src/test/domains.test.ts
+++ b/src/test/domains.test.ts
@@ -119,7 +119,7 @@ describe('Domain SDK', () => {
   });
 
   describe('getDomains', () => {
-    it.only('returns all the domains in the catalog,', async () => {
+    it('returns all the domains in the catalog,', async () => {
       // versioned domain
       await writeDomain({
         id: 'InventoryAdjusted',

--- a/src/test/domains.test.ts
+++ b/src/test/domains.test.ts
@@ -10,6 +10,7 @@ const {
   writeDomain,
   getDomain,
   getDomains,
+  writeService,
   versionDomain,
   rmDomain,
   rmDomainById,
@@ -118,7 +119,7 @@ describe('Domain SDK', () => {
   });
 
   describe('getDomains', () => {
-    it('returns all the domains in the catalog,', async () => {
+    it.only('returns all the domains in the catalog,', async () => {
       // versioned domain
       await writeDomain({
         id: 'InventoryAdjusted',
@@ -140,31 +141,12 @@ describe('Domain SDK', () => {
         { versionExistingContent: true }
       );
 
-      // domain in the services folder
-      await writeDomain(
-        {
-          id: 'OrderComplete',
-          name: 'Order Complete',
-          version: '1.0.0',
-          summary: 'This is a summary',
-          markdown: '# Hello world',
-        },
-        { path: '/services/OrderService' }
-      );
-
       const domains = await getDomains();
 
       expect(domains).toEqual([
         {
           id: 'InventoryAdjusted',
           name: 'Inventory Adjusted',
-          version: '1.0.0',
-          summary: 'This is a summary',
-          markdown: '# Hello world',
-        },
-        {
-          id: 'OrderComplete',
-          name: 'Order Complete',
           version: '1.0.0',
           summary: 'This is a summary',
           markdown: '# Hello world',
@@ -178,6 +160,41 @@ describe('Domain SDK', () => {
         },
       ]);
     });
+
+    it('when services are nested into the domains folder it only returns the domains', async () => {
+      // versioned domain
+      await writeDomain({
+        id: 'Inventory',
+        name: 'Inventory',
+        version: '0.0.1',
+        summary: 'This is a summary',
+        markdown: '# Hello world',
+      });
+
+      await writeService(
+        {
+          id: 'InventoryService',
+          version: '1.0.0',
+          name: 'Inventory Service',
+          summary: 'This is a summary',
+          markdown: '# Hello world',
+        },
+        { path: '/domains/writeDomain' }
+      );
+
+      const domains = await getDomains();
+
+      expect(domains).toEqual([
+        {
+          id: 'Inventory',
+          name: 'Inventory',
+          version: '0.0.1',
+          summary: 'This is a summary',
+          markdown: '# Hello world',
+        },
+      ]);
+    });
+
     it('returns only the latest domains when `latestOnly` is set to true,', async () => {
       // versioned domain
       await writeDomain({
@@ -205,18 +222,6 @@ describe('Domain SDK', () => {
         {
           id: 'OrderComplete',
           name: 'Order Complete',
-          version: '1.0.0',
-          summary: 'This is a summary',
-          markdown: '# Hello world',
-        },
-        { path: '/services/OrderService' }
-      );
-
-      // domain in the services folder
-      await writeDomain(
-        {
-          id: 'OrderComplete',
-          name: 'Order Complete',
           version: '2.0.0',
           summary: 'This is a summary',
           markdown: '# Hello world',
@@ -231,13 +236,6 @@ describe('Domain SDK', () => {
           id: 'InventoryAdjusted',
           name: 'Inventory Adjusted',
           version: '1.0.0',
-          summary: 'This is a summary',
-          markdown: '# Hello world',
-        },
-        {
-          id: 'OrderComplete',
-          name: 'Order Complete',
-          version: '2.0.0',
           summary: 'This is a summary',
           markdown: '# Hello world',
         },

--- a/src/test/services.test.ts
+++ b/src/test/services.test.ts
@@ -11,6 +11,7 @@ const {
   writeService,
   writeServiceToDomain,
   writeVersionedService,
+  writeEvent,
   getService,
   getServices,
   versionService,
@@ -299,6 +300,40 @@ describe('Services SDK', () => {
         },
       ]);
     });
+
+    it('when messages are nested into the service folder it only returns the services', async () => {
+      await writeService({
+        id: 'InventoryService',
+        name: 'Inventory Service',
+        version: '0.0.1',
+        summary: 'This is a summary',
+        markdown: '# Hello world',
+      });
+
+      await writeEvent(
+        {
+          id: 'InventoryUpdatedEvent',
+          version: '2.0.0',
+          summary: 'This is a summary',
+          markdown: '# Hello world',
+          name: 'Inventory Updated Event',
+        },
+        { path: '/services/InventoryService' }
+      );
+
+      const services = await getServices();
+
+      expect(services).toEqual([
+        {
+          id: 'InventoryService',
+          name: 'Inventory Service',
+          version: '0.0.1',
+          summary: 'This is a summary',
+          markdown: '# Hello world',
+        },
+      ]);
+    });
+
     it('returns only the latest services when `latestOnly` is set to true,', async () => {
       // versioned service
       await writeService({


### PR DESCRIPTION
Had an issue when you have tested structures, and called getServices or getDomains, they would return all nested resources, they now only return the correct resource.