### PR TITLE
(feat) WriteResource includes a draft changelog.md by default

### DIFF
--- a/.changeset/new-needles-collect.md
+++ b/.changeset/new-needles-collect.md
@@ -1,0 +1,5 @@
+---
+'@eventcatalog/sdk': minor
+---
+
+WriteResource now includes a draft changelog.md by default

--- a/src/internal/resources.ts
+++ b/src/internal/resources.ts
@@ -96,6 +96,17 @@ export const writeResource = async (
 
     const document = matter.stringify(markdown.trim(), frontmatter);
     fsSync.writeFileSync(lockPath, document);
+
+    // Add empty changelog with generated date to resource
+    await addFileToResource(
+      catalogDir,
+      resource.id,
+      {
+        content: '---\ncreatedAt: ' + new Date().toISOString().split('T')[0] + '\n---',
+        fileName: 'changelog.md',
+      },
+      resource.version
+    );
   } finally {
     // Always release the lock
     await unlock(lockPath).catch(() => {});

--- a/src/internal/utils.ts
+++ b/src/internal/utils.ts
@@ -1,10 +1,9 @@
-import { glob, globSync } from 'glob';
-import fs from 'node:fs/promises';
+import { globSync } from 'glob';
 import fsSync from 'node:fs';
-import { copy, copySync, CopyFilterAsync, CopyFilterSync } from 'fs-extra';
+import { copy, CopyFilterAsync, CopyFilterSync } from 'fs-extra';
 import { join } from 'node:path';
 import matter from 'gray-matter';
-import { satisfies, validRange, valid } from 'semver';
+import { satisfies, valid, validRange } from 'semver';
 
 /**
  * Returns true if a given version of a resource id exists in the catalog
@@ -108,7 +107,7 @@ export const copyDir = async (catalogDir: string, source: string, target: string
   fsSync.rmSync(tmpDirectory, { recursive: true });
 };
 
-// Makes sure values in sends/recieves are unique
+// Makes sure values in sends/receives are unique
 export const uniqueVersions = (messages: { id: string; version: string }[]): { id: string; version: string }[] => {
   const uniqueSet = new Set();
 

--- a/src/test/channels.test.ts
+++ b/src/test/channels.test.ts
@@ -411,6 +411,7 @@ describe('Channels SDK', () => {
       const channel = await getChannel('inventory.{env}.events');
 
       expect(fs.existsSync(path.join(CATALOG_PATH, 'channels/inventory.{env}.events', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'channels/inventory.{env}.events', 'changelog.md'))).toBe(true);
 
       expect(channel).toEqual({
         id: 'inventory.{env}.events',

--- a/src/test/commands.test.ts
+++ b/src/test/commands.test.ts
@@ -289,6 +289,7 @@ describe('Commands SDK', () => {
       const command = await getCommand('UpdateInventory');
 
       expect(fs.existsSync(path.join(CATALOG_PATH, 'commands/UpdateInventory', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'commands/UpdateInventory', 'changelog.md'))).toBe(true);
 
       expect(command).toEqual({
         id: 'UpdateInventory',

--- a/src/test/domains.test.ts
+++ b/src/test/domains.test.ts
@@ -256,6 +256,7 @@ describe('Domain SDK', () => {
       const domain = await getDomain('Payment');
 
       expect(fs.existsSync(path.join(CATALOG_PATH, 'domains/Payment', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'domains/Payment', 'changelog.md'))).toBe(true);
 
       expect(domain).toEqual({
         id: 'Payment',

--- a/src/test/events.test.ts
+++ b/src/test/events.test.ts
@@ -505,6 +505,7 @@ describe('Events SDK', () => {
       const event = await getEvent('InventoryAdjusted');
 
       expect(fs.existsSync(path.join(CATALOG_PATH, 'events/InventoryAdjusted', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'events/InventoryAdjusted', 'changelog.md'))).toBe(true);
 
       expect(event).toEqual({
         id: 'InventoryAdjusted',

--- a/src/test/queries.test.ts
+++ b/src/test/queries.test.ts
@@ -505,6 +505,7 @@ describe('Queries SDK', () => {
       const query = await getQuery('GetOrder');
 
       expect(fs.existsSync(path.join(CATALOG_PATH, 'queries/GetOrder', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'queries/GetOrder', 'changelog.md'))).toBe(true);
 
       expect(query).toEqual({
         id: 'GetOrder',

--- a/src/test/services.test.ts
+++ b/src/test/services.test.ts
@@ -426,6 +426,7 @@ describe('Services SDK', () => {
       const service = await getService('InventoryService');
 
       expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService', 'changelog.md'))).toBe(true);
 
       expect(service).toEqual({
         id: 'InventoryService',


### PR DESCRIPTION
## Motivation

I noticed that it was very cumbersome to manually add the changelog.md to resources whether new or versioned, so I'm proposing to include a draft changelog.md that just includes the generation date, so that one can quickly move towards just writing what changed in the changelogs.

Since this seemed to be reasonable to have whether by programmatically calling the sdk or in the generation, I decided to introduce it at the level of the sdk.

Another possibility would be to just expose a addChangelogToResource method in the sdk and then calling it from the generators, but what might be more interesting would be something like addChangelogContentToResource if one wanted to programmatically update changelogs, in which case it would still be reasonable that there be a changelog.md by default.

If you guys disagree, let me know your thoughts. :)