### PR TITLE
fix(sdk): getDomains no longer returns flows

### DIFF
--- a/.changeset/fresh-books-tease.md
+++ b/.changeset/fresh-books-tease.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/sdk": patch
+---
+
+fix(sdk): getDomains no longer returns flows

--- a/src/domains.ts
+++ b/src/domains.ts
@@ -57,7 +57,7 @@ export const getDomains =
   async (options?: { latestOnly?: boolean }): Promise<Domain[]> =>
     getResources(directory, {
       type: 'domains',
-      ignore: ['**/services/**', '**/events/**', '**/commands/**', '**/queries/**'],
+      ignore: ['**/services/**', '**/events/**', '**/commands/**', '**/queries/**', '**/flows/**'],
       ...options,
     }) as Promise<Domain[]>;
 


### PR DESCRIPTION
found an issue where `getDomains` was returning flows as part of its calls.

Flows are no longer returned through the SDK.