### PR TITLE
chore(sdk): moving to mdx files

### DIFF
--- a/.changeset/lucky-zebras-attend.md
+++ b/.changeset/lucky-zebras-attend.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/sdk": major
+---
+
+chore(sdk): moving to mdx files

--- a/src/internal/resources.ts
+++ b/src/internal/resources.ts
@@ -11,7 +11,7 @@ type Resource = Service | Message;
 
 export const versionResource = async (catalogDir: string, id: string) => {
   // Find all the events in the directory
-  const files = await getFiles(`${catalogDir}/**/index.md`);
+  const files = await getFiles(`${catalogDir}/**/index.{md,mdx}`);
   const matchedFiles = await searchFilesForId(files, id);
 
   if (matchedFiles.length === 0) {
@@ -60,7 +60,7 @@ export const writeResource = async (
   fsSync.mkdirSync(fullPath, { recursive: true });
 
   // Create or get lock file path
-  const lockPath = join(fullPath, 'index.md');
+  const lockPath = join(fullPath, 'index.mdx');
 
   // Ensure the file exists before attempting to lock it
   if (!fsSync.existsSync(lockPath)) {
@@ -124,7 +124,7 @@ export const getResources = async (
   { type, latestOnly = false, ignore = [] }: { type: string; latestOnly?: boolean; ignore?: string[] }
 ): Promise<Resource[] | undefined> => {
   const ignoreList = latestOnly ? `**/versioned/**` : '';
-  const files = await getFiles(`${catalogDir}/**/${type}/**/index.md`, [ignoreList, ...ignore]);
+  const files = await getFiles(`${catalogDir}/**/${type}/**/index.{md,mdx}`, [ignoreList, ...ignore]);
   if (files.length === 0) return;
 
   return files.map((file) => {
@@ -142,7 +142,7 @@ export const rmResourceById = async (
   version?: string,
   options?: { type: string; persistFiles?: boolean }
 ) => {
-  const files = await getFiles(`${catalogDir}/**/index.md`);
+  const files = await getFiles(`${catalogDir}/**/index.{md,mdx}`);
 
   const matchedFiles = await searchFilesForId(files, id, version);
 

--- a/src/internal/utils.ts
+++ b/src/internal/utils.ts
@@ -10,13 +10,14 @@ import { satisfies, validRange, valid } from 'semver';
  * Returns true if a given version of a resource id exists in the catalog
  */
 export const versionExists = async (catalogDir: string, id: string, version: string) => {
-  const files = await getFiles(`${catalogDir}/**/index.md`);
+  const files = await getFiles(`${catalogDir}/**/index.{md,mdx}`);
   const matchedFiles = (await searchFilesForId(files, id, version)) || [];
   return matchedFiles.length > 0;
 };
 
 export const findFileById = async (catalogDir: string, id: string, version?: string): Promise<string | undefined> => {
-  const files = await getFiles(`${catalogDir}/**/index.md`);
+  const files = await getFiles(`${catalogDir}/**/index.{md,mdx}`);
+
   const matchedFiles = (await searchFilesForId(files, id)) || [];
   const latestVersion = matchedFiles.find((path) => !path.includes('versioned'));
 

--- a/src/test/channels.test.ts
+++ b/src/test/channels.test.ts
@@ -410,7 +410,7 @@ describe('Channels SDK', () => {
 
       const channel = await getChannel('inventory.{env}.events');
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'channels/inventory.{env}.events', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'channels/inventory.{env}.events', 'index.mdx'))).toBe(true);
 
       expect(channel).toEqual({
         id: 'inventory.{env}.events',
@@ -433,7 +433,7 @@ describe('Channels SDK', () => {
     it('writes the given channel to EventCatalog under the correct path when a path is given', async () => {
       await writeChannel(mockChannel, { path: '/Inventory/InventoryChannel' });
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'channels/Inventory/InventoryChannel', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'channels/Inventory/InventoryChannel', 'index.mdx'))).toBe(true);
     });
 
     it('throws an error when trying to write an channel that already exists', async () => {
@@ -453,7 +453,7 @@ describe('Channels SDK', () => {
 
       const channel = await getChannel('inventory.{env}.events');
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'channels/inventory.{env}.events', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'channels/inventory.{env}.events', 'index.mdx'))).toBe(true);
       expect(channel.markdown).toBe('Overridden content');
     });
 
@@ -474,8 +474,8 @@ describe('Channels SDK', () => {
         expect(channel.version).toBe('1.0.0');
         expect(channel.markdown).toBe('New');
 
-        expect(fs.existsSync(path.join(CATALOG_PATH, 'channels/inventory.{env}.events/versioned/0.0.1', 'index.md'))).toBe(true);
-        expect(fs.existsSync(path.join(CATALOG_PATH, 'channels/inventory.{env}.events', 'index.md'))).toBe(true);
+        expect(fs.existsSync(path.join(CATALOG_PATH, 'channels/inventory.{env}.events/versioned/0.0.1', 'index.mdx'))).toBe(true);
+        expect(fs.existsSync(path.join(CATALOG_PATH, 'channels/inventory.{env}.events', 'index.mdx'))).toBe(true);
       });
 
       it('throws an error when trying to write an channel and versionExistingContent is true and the new version number is not greater than the previous one', async () => {
@@ -492,11 +492,11 @@ describe('Channels SDK', () => {
     it('removes a channel from eventcatalog', async () => {
       await writeChannel(mockChannel);
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'channels/inventory.{env}.events', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'channels/inventory.{env}.events', 'index.mdx'))).toBe(true);
 
       await rmChannel('/inventory.{env}.events');
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'channels/inventory.{env}.events', 'index.md'))).toBe(false);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'channels/inventory.{env}.events', 'index.mdx'))).toBe(false);
     });
   });
 
@@ -504,21 +504,21 @@ describe('Channels SDK', () => {
     it('removes an channel from eventcatalog by id', async () => {
       await writeChannel(mockChannel);
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'channels/inventory.{env}.events', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'channels/inventory.{env}.events', 'index.mdx'))).toBe(true);
 
       await rmChannelById('inventory.{env}.events');
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'channels/inventory.{env}.events', 'index.md'))).toBe(false);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'channels/inventory.{env}.events', 'index.mdx'))).toBe(false);
     });
 
     it('removes an channel from eventcatalog by id and version', async () => {
       await writeChannel(mockChannel);
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'channels/inventory.{env}.events', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'channels/inventory.{env}.events', 'index.mdx'))).toBe(true);
 
       await rmChannelById('inventory.{env}.events', '0.0.1');
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'channels/inventory.{env}.events', 'index.md'))).toBe(false);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'channels/inventory.{env}.events', 'index.mdx'))).toBe(false);
     });
 
     it('if version is given, only removes that version and not any other versions of the channel', async () => {
@@ -532,14 +532,14 @@ describe('Channels SDK', () => {
         version: '0.0.2',
       });
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'channels/inventory.{env}.events', 'index.md'))).toBe(true);
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'channels/inventory.{env}.events/versioned/0.0.1', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'channels/inventory.{env}.events', 'index.mdx'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'channels/inventory.{env}.events/versioned/0.0.1', 'index.mdx'))).toBe(true);
 
       await rmChannelById('inventory.{env}.events', '0.0.1');
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'channels/inventory.{env}.events', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'channels/inventory.{env}.events', 'index.mdx'))).toBe(true);
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'channels/inventory.{env}.events/versioned/0.0.2', 'index.md'))).toBe(false);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'channels/inventory.{env}.events/versioned/0.0.2', 'index.mdx'))).toBe(false);
     });
   });
 
@@ -549,9 +549,9 @@ describe('Channels SDK', () => {
 
       await versionChannel('inventory.{env}.events');
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'channels/inventory.{env}.events/versioned/0.0.1', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'channels/inventory.{env}.events/versioned/0.0.1', 'index.mdx'))).toBe(true);
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'channels/inventory.{env}.events', 'index.md'))).toBe(false);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'channels/inventory.{env}.events', 'index.mdx'))).toBe(false);
     });
 
     // channel tends not to have any files associated with it (yet)
@@ -563,11 +563,11 @@ describe('Channels SDK', () => {
 
       await versionChannel('inventory.{env}.events');
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'channels/inventory.{env}.events/versioned/0.0.1', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'channels/inventory.{env}.events/versioned/0.0.1', 'index.mdx'))).toBe(true);
 
       expect(fs.existsSync(path.join(CATALOG_PATH, 'channels/inventory.{env}.events/versioned/0.0.1', 'schema.json'))).toBe(true);
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'channels/inventory.{env}.events', 'index.md'))).toBe(false);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'channels/inventory.{env}.events', 'index.mdx'))).toBe(false);
 
       expect(fs.existsSync(path.join(CATALOG_PATH, 'channels/inventory.{env}.events', 'schema.json'))).toBe(false);
     });
@@ -622,7 +622,7 @@ describe('Channels SDK', () => {
         const event = await getEvent('InventoryCreated');
 
         // expect the path
-        expect(fs.existsSync(path.join(CATALOG_PATH, 'events/InventoryCreated', 'index.md'))).toBe(true);
+        expect(fs.existsSync(path.join(CATALOG_PATH, 'events/InventoryCreated', 'index.mdx'))).toBe(true);
 
         expect(event.channels).toEqual([
           {

--- a/src/test/commands.test.ts
+++ b/src/test/commands.test.ts
@@ -288,7 +288,7 @@ describe('Commands SDK', () => {
 
       const command = await getCommand('UpdateInventory');
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'commands/UpdateInventory', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'commands/UpdateInventory', 'index.mdx'))).toBe(true);
 
       expect(command).toEqual({
         id: 'UpdateInventory',
@@ -311,7 +311,7 @@ describe('Commands SDK', () => {
         { path: '/Inventory/UpdateInventory' }
       );
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'commands/Inventory/UpdateInventory', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'commands/Inventory/UpdateInventory', 'index.mdx'))).toBe(true);
     });
 
     it('throws an error when trying to write an command that already exists', async () => {
@@ -362,8 +362,8 @@ describe('Commands SDK', () => {
         expect(channel.version).toBe('1.0.0');
         expect(channel.markdown).toBe('New');
 
-        expect(fs.existsSync(path.join(CATALOG_PATH, 'commands/UpdateInventory/versioned/0.0.1', 'index.md'))).toBe(true);
-        expect(fs.existsSync(path.join(CATALOG_PATH, 'commands/UpdateInventory', 'index.md'))).toBe(true);
+        expect(fs.existsSync(path.join(CATALOG_PATH, 'commands/UpdateInventory/versioned/0.0.1', 'index.mdx'))).toBe(true);
+        expect(fs.existsSync(path.join(CATALOG_PATH, 'commands/UpdateInventory', 'index.mdx'))).toBe(true);
       });
 
       it('throws an error when trying to write an channel and versionExistingContent is true and the new version number is not greater than the previous one', async () => {
@@ -409,7 +409,9 @@ describe('Commands SDK', () => {
         }
       );
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService/commands/UpdateInventory', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService/commands/UpdateInventory', 'index.mdx'))).toBe(
+        true
+      );
     });
     it('writes a command to the given service. When a version is given for the command the service is added to that service version', async () => {
       await writeCommandToService(
@@ -426,7 +428,7 @@ describe('Commands SDK', () => {
         }
       );
       expect(
-        fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService/versioned/1.0.0/commands/UpdateInventory', 'index.md'))
+        fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService/versioned/1.0.0/commands/UpdateInventory', 'index.mdx'))
       ).toBe(true);
     });
     it('writes a command to the given service. When a version is the latest the command is added to the latest version of the service', async () => {
@@ -443,7 +445,9 @@ describe('Commands SDK', () => {
           version: 'latest',
         }
       );
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService/commands/UpdateInventory', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService/commands/UpdateInventory', 'index.mdx'))).toBe(
+        true
+      );
     });
   });
 
@@ -457,11 +461,11 @@ describe('Commands SDK', () => {
         markdown: '# Hello world',
       });
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'commands/UpdateInventory', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'commands/UpdateInventory', 'index.mdx'))).toBe(true);
 
       await rmCommand('/UpdateInventory');
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'commands/UpdateInventory', 'index.md'))).toBe(false);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'commands/UpdateInventory', 'index.mdx'))).toBe(false);
     });
   });
 
@@ -475,11 +479,11 @@ describe('Commands SDK', () => {
         markdown: '# Hello world',
       });
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'commands/UpdateInventory', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'commands/UpdateInventory', 'index.mdx'))).toBe(true);
 
       await rmCommandById('UpdateInventory');
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'commands/UpdateInventory', 'index.md'))).toBe(false);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'commands/UpdateInventory', 'index.mdx'))).toBe(false);
     });
 
     it('removes a command and all files in that command', async () => {
@@ -493,11 +497,11 @@ describe('Commands SDK', () => {
 
       fs.writeFileSync(path.join(CATALOG_PATH, 'commands/UpdateInventory', 'schema.json'), 'SCHEMA!');
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'commands/UpdateInventory', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'commands/UpdateInventory', 'index.mdx'))).toBe(true);
 
       await rmCommandById('UpdateInventory');
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'commands/UpdateInventory', 'index.md'))).toBe(false);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'commands/UpdateInventory', 'index.mdx'))).toBe(false);
       expect(fs.existsSync(path.join(CATALOG_PATH, 'commands/UpdateInventory', 'schema.json'))).toBe(false);
     });
 
@@ -512,11 +516,11 @@ describe('Commands SDK', () => {
 
       fs.writeFileSync(path.join(CATALOG_PATH, 'commands/UpdateInventory', 'schema.json'), 'SCHEMA!');
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'commands/UpdateInventory', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'commands/UpdateInventory', 'index.mdx'))).toBe(true);
 
       await rmCommandById('UpdateInventory', '0.0.1', true);
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'commands/UpdateInventory', 'index.md'))).toBe(false);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'commands/UpdateInventory', 'index.mdx'))).toBe(false);
       expect(fs.existsSync(path.join(CATALOG_PATH, 'commands/UpdateInventory', 'schema.json'))).toBe(true);
     });
 
@@ -529,11 +533,11 @@ describe('Commands SDK', () => {
         markdown: '# Hello world',
       });
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'commands/UpdateInventory', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'commands/UpdateInventory', 'index.mdx'))).toBe(true);
 
       await rmCommandById('UpdateInventory', '0.0.1');
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'commands/UpdateInventory', 'index.md'))).toBe(false);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'commands/UpdateInventory', 'index.mdx'))).toBe(false);
     });
 
     it('if version is given, only removes that version and not any other versions of the command', async () => {
@@ -556,14 +560,14 @@ describe('Commands SDK', () => {
         markdown: '# Hello world',
       });
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'commands/UpdateInventory', 'index.md'))).toBe(true);
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'commands/UpdateInventory/versioned/0.0.1', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'commands/UpdateInventory', 'index.mdx'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'commands/UpdateInventory/versioned/0.0.1', 'index.mdx'))).toBe(true);
 
       await rmCommandById('UpdateInventory', '0.0.1');
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'commands/UpdateInventory', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'commands/UpdateInventory', 'index.mdx'))).toBe(true);
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'commands/UpdateInventory/versioned/0.0.2', 'index.md'))).toBe(false);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'commands/UpdateInventory/versioned/0.0.2', 'index.mdx'))).toBe(false);
     });
 
     describe('when commands are within a service directory', () => {
@@ -579,11 +583,11 @@ describe('Commands SDK', () => {
           { id: 'Inventory' }
         );
 
-        expect(fs.existsSync(path.join(CATALOG_PATH, 'services/Inventory/commands/UpdateInventory', 'index.md'))).toBe(true);
+        expect(fs.existsSync(path.join(CATALOG_PATH, 'services/Inventory/commands/UpdateInventory', 'index.mdx'))).toBe(true);
 
         await rmCommandById('UpdateInventory');
 
-        expect(fs.existsSync(path.join(CATALOG_PATH, 'services/Inventory/commands/UpdateInventory', 'index.md'))).toBe(false);
+        expect(fs.existsSync(path.join(CATALOG_PATH, 'services/Inventory/commands/UpdateInventory', 'index.mdx'))).toBe(false);
       });
 
       it('if version is given, only removes that version and not any other versions of the command', async () => {
@@ -612,17 +616,17 @@ describe('Commands SDK', () => {
           { id: 'Inventory' }
         );
 
-        expect(fs.existsSync(path.join(CATALOG_PATH, 'services/Inventory/commands/UpdateInventory', 'index.md'))).toBe(true);
+        expect(fs.existsSync(path.join(CATALOG_PATH, 'services/Inventory/commands/UpdateInventory', 'index.mdx'))).toBe(true);
         expect(
-          fs.existsSync(path.join(CATALOG_PATH, 'services/Inventory/commands/UpdateInventory/versioned/0.0.1', 'index.md'))
+          fs.existsSync(path.join(CATALOG_PATH, 'services/Inventory/commands/UpdateInventory/versioned/0.0.1', 'index.mdx'))
         ).toBe(true);
 
         await rmCommandById('UpdateInventory', '0.0.1');
 
-        expect(fs.existsSync(path.join(CATALOG_PATH, 'services/Inventory/commands/UpdateInventory', 'index.md'))).toBe(true);
+        expect(fs.existsSync(path.join(CATALOG_PATH, 'services/Inventory/commands/UpdateInventory', 'index.mdx'))).toBe(true);
 
         expect(
-          fs.existsSync(path.join(CATALOG_PATH, 'services/Inventory/commands/UpdateInventory/versioned/0.0.2', 'index.md'))
+          fs.existsSync(path.join(CATALOG_PATH, 'services/Inventory/commands/UpdateInventory/versioned/0.0.2', 'index.mdx'))
         ).toBe(false);
       });
     });
@@ -643,9 +647,9 @@ describe('Commands SDK', () => {
 
       await versionCommand('UpdateInventory');
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'commands/UpdateInventory/versioned/0.0.2', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'commands/UpdateInventory/versioned/0.0.2', 'index.mdx'))).toBe(true);
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'commands/UpdateInventory', 'index.md'))).toBe(false);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'commands/UpdateInventory', 'index.mdx'))).toBe(false);
     });
     it('adds the given command to the versioned directory and all files that are associated to it', async () => {
       await writeCommand({
@@ -661,11 +665,11 @@ describe('Commands SDK', () => {
 
       await versionCommand('UpdateInventory');
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'commands/UpdateInventory/versioned/0.0.2', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'commands/UpdateInventory/versioned/0.0.2', 'index.mdx'))).toBe(true);
 
       expect(fs.existsSync(path.join(CATALOG_PATH, 'commands/UpdateInventory/versioned/0.0.2', 'schema.json'))).toBe(true);
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'commands/UpdateInventory', 'index.md'))).toBe(false);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'commands/UpdateInventory', 'index.mdx'))).toBe(false);
 
       expect(fs.existsSync(path.join(CATALOG_PATH, 'commands/UpdateInventory', 'schema.json'))).toBe(false);
     });
@@ -689,10 +693,10 @@ describe('Commands SDK', () => {
         await versionCommand('UpdateInventory');
 
         expect(
-          fs.existsSync(path.join(CATALOG_PATH, 'services/Inventory/commands/UpdateInventory/versioned/0.0.2', 'index.md'))
+          fs.existsSync(path.join(CATALOG_PATH, 'services/Inventory/commands/UpdateInventory/versioned/0.0.2', 'index.mdx'))
         ).toBe(true);
 
-        expect(fs.existsSync(path.join(CATALOG_PATH, 'services/Inventory/commands/UpdateInventory', 'index.md'))).toBe(false);
+        expect(fs.existsSync(path.join(CATALOG_PATH, 'services/Inventory/commands/UpdateInventory', 'index.mdx'))).toBe(false);
       });
       it('adds the given command to the versioned directory and all files that are associated to it', async () => {
         await writeCommandToService(
@@ -712,14 +716,14 @@ describe('Commands SDK', () => {
         await versionCommand('UpdateInventory');
 
         expect(
-          fs.existsSync(path.join(CATALOG_PATH, 'services/Inventory/commands/UpdateInventory/versioned/0.0.2', 'index.md'))
+          fs.existsSync(path.join(CATALOG_PATH, 'services/Inventory/commands/UpdateInventory/versioned/0.0.2', 'index.mdx'))
         ).toBe(true);
 
         expect(
           fs.existsSync(path.join(CATALOG_PATH, 'services/Inventory/commands/UpdateInventory/versioned/0.0.2', 'schema.json'))
         ).toBe(true);
 
-        expect(fs.existsSync(path.join(CATALOG_PATH, 'services/Inventory/commands/UpdateInventory', 'index.md'))).toBe(false);
+        expect(fs.existsSync(path.join(CATALOG_PATH, 'services/Inventory/commands/UpdateInventory', 'index.mdx'))).toBe(false);
 
         expect(fs.existsSync(path.join(CATALOG_PATH, 'services/Inventory/commands/UpdateInventory', 'schema.json'))).toBe(false);
       });
@@ -792,7 +796,7 @@ describe('Commands SDK', () => {
 
       const command = await getCommand('AdjustInventory');
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'commands/AdjustInventory', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'commands/AdjustInventory', 'index.mdx'))).toBe(true);
       expect(command.markdown).toBe('Overridden content');
     });
 

--- a/src/test/domains.test.ts
+++ b/src/test/domains.test.ts
@@ -255,7 +255,7 @@ describe('Domain SDK', () => {
 
       const domain = await getDomain('Payment');
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'domains/Payment', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'domains/Payment', 'index.mdx'))).toBe(true);
 
       expect(domain).toEqual({
         id: 'Payment',
@@ -278,7 +278,7 @@ describe('Domain SDK', () => {
         { path: '/Inventory/Payment' }
       );
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'domains/Inventory/Payment', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'domains/Inventory/Payment', 'index.mdx'))).toBe(true);
     });
 
     it('services written to a domain are always unique', async () => {
@@ -361,7 +361,7 @@ describe('Domain SDK', () => {
 
       const service = await getDomain('Payment');
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'domains/Payment', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'domains/Payment', 'index.mdx'))).toBe(true);
       expect(service.markdown).toBe('Overridden content');
     });
 
@@ -390,8 +390,8 @@ describe('Domain SDK', () => {
         expect(domain.version).toBe('1.0.0');
         expect(domain.markdown).toBe('New');
 
-        expect(fs.existsSync(path.join(CATALOG_PATH, 'domains/Payment/versioned/0.0.1', 'index.md'))).toBe(true);
-        expect(fs.existsSync(path.join(CATALOG_PATH, 'domains/Payment', 'index.md'))).toBe(true);
+        expect(fs.existsSync(path.join(CATALOG_PATH, 'domains/Payment/versioned/0.0.1', 'index.mdx'))).toBe(true);
+        expect(fs.existsSync(path.join(CATALOG_PATH, 'domains/Payment', 'index.mdx'))).toBe(true);
       });
 
       it('throws an error when trying to write a domain and versionExistingContent is true and the new version number is not greater than the previous one', async () => {
@@ -434,8 +434,8 @@ describe('Domain SDK', () => {
 
       await versionDomain('Payment');
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'domains/Payment/versioned/0.0.1', 'index.md'))).toBe(true);
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'domains/Payment', 'index.md'))).toBe(false);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'domains/Payment/versioned/0.0.1', 'index.mdx'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'domains/Payment', 'index.mdx'))).toBe(false);
     });
     it('adds the given domain to the versioned directory and all files that are associated to it', async () => {
       await writeDomain({
@@ -451,9 +451,9 @@ describe('Domain SDK', () => {
 
       await versionDomain('Payment');
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'domains/Payment/versioned/0.0.1', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'domains/Payment/versioned/0.0.1', 'index.mdx'))).toBe(true);
       expect(fs.existsSync(path.join(CATALOG_PATH, 'domains/Payment/versioned/0.0.1', 'schema.json'))).toBe(true);
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'domains/Payment', 'index.md'))).toBe(false);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'domains/Payment', 'index.mdx'))).toBe(false);
       expect(fs.existsSync(path.join(CATALOG_PATH, 'domains/Payment', 'schema.json'))).toBe(false);
     });
   });
@@ -468,11 +468,11 @@ describe('Domain SDK', () => {
         markdown: '# Hello world',
       });
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'domains/Payment', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'domains/Payment', 'index.mdx'))).toBe(true);
 
       await rmDomain('/Payment');
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'domains/Payment', 'index.md'))).toBe(false);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'domains/Payment', 'index.mdx'))).toBe(false);
     });
   });
 
@@ -486,11 +486,11 @@ describe('Domain SDK', () => {
         markdown: '# Hello world',
       });
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'domains/Payment', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'domains/Payment', 'index.mdx'))).toBe(true);
 
       await rmDomainById('Payment');
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'domains/Payment', 'index.md'))).toBe(false);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'domains/Payment', 'index.mdx'))).toBe(false);
     });
 
     it('removes a domain from eventcatalog by id and version', async () => {
@@ -502,11 +502,11 @@ describe('Domain SDK', () => {
         markdown: '# Hello world',
       });
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'domains/Payment', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'domains/Payment', 'index.mdx'))).toBe(true);
 
       await rmDomainById('Payment', '0.0.1');
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'domains/Payment', 'index.md'))).toBe(false);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'domains/Payment', 'index.mdx'))).toBe(false);
     });
 
     it('if version is given, only removes that version and not any other versions of the domain', async () => {
@@ -530,14 +530,14 @@ describe('Domain SDK', () => {
         markdown: '# Hello world',
       });
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'domains/Payment', 'index.md'))).toBe(true);
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'domains/Payment/versioned/0.0.1', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'domains/Payment', 'index.mdx'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'domains/Payment/versioned/0.0.1', 'index.mdx'))).toBe(true);
 
       await rmDomainById('Payment', '0.0.1');
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'domains/Payment', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'domains/Payment', 'index.mdx'))).toBe(true);
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'domains/InventoryAdjusted/versioned/0.0.2', 'index.md'))).toBe(false);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'domains/InventoryAdjusted/versioned/0.0.2', 'index.mdx'))).toBe(false);
     });
   });
 

--- a/src/test/events.test.ts
+++ b/src/test/events.test.ts
@@ -504,7 +504,7 @@ describe('Events SDK', () => {
 
       const event = await getEvent('InventoryAdjusted');
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'events/InventoryAdjusted', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'events/InventoryAdjusted', 'index.mdx'))).toBe(true);
 
       expect(event).toEqual({
         id: 'InventoryAdjusted',
@@ -527,7 +527,7 @@ describe('Events SDK', () => {
         { path: '/Inventory/InventoryAdjusted' }
       );
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'events/Inventory/InventoryAdjusted', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'events/Inventory/InventoryAdjusted', 'index.mdx'))).toBe(true);
     });
 
     it('throws an error when trying to write an event that already exists (and override is false, default)', async () => {
@@ -577,7 +577,7 @@ describe('Events SDK', () => {
 
       const event = await getEvent('InventoryAdjusted');
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'events/InventoryAdjusted', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'events/InventoryAdjusted', 'index.mdx'))).toBe(true);
       expect(event.markdown).toBe('Overridden content');
     });
 
@@ -608,8 +608,8 @@ describe('Events SDK', () => {
         expect(event.markdown).toBe('New Content!');
         expect(event.version).toBe('1.0.0');
 
-        expect(fs.existsSync(path.join(CATALOG_PATH, 'events/InventoryAdjusted/versioned/0.0.1', 'index.md'))).toBe(true);
-        expect(fs.existsSync(path.join(CATALOG_PATH, 'events/InventoryAdjusted', 'index.md'))).toBe(true);
+        expect(fs.existsSync(path.join(CATALOG_PATH, 'events/InventoryAdjusted/versioned/0.0.1', 'index.mdx'))).toBe(true);
+        expect(fs.existsSync(path.join(CATALOG_PATH, 'events/InventoryAdjusted', 'index.mdx'))).toBe(true);
       });
 
       it('does not version the previous event but overrides it when versionExistingContent is true and override is also true', async () => {
@@ -639,8 +639,8 @@ describe('Events SDK', () => {
         expect(event.markdown).toBe('New Content!');
         expect(event.version).toBe('0.0.1');
 
-        expect(fs.existsSync(path.join(CATALOG_PATH, 'events/InventoryAdjusted/versioned/0.0.1', 'index.md'))).toBe(false);
-        expect(fs.existsSync(path.join(CATALOG_PATH, 'events/InventoryAdjusted', 'index.md'))).toBe(true);
+        expect(fs.existsSync(path.join(CATALOG_PATH, 'events/InventoryAdjusted/versioned/0.0.1', 'index.mdx'))).toBe(false);
+        expect(fs.existsSync(path.join(CATALOG_PATH, 'events/InventoryAdjusted', 'index.mdx'))).toBe(true);
       });
 
       it('throws an error when trying to write an event and versionExistingEvent is true and the new version number is not greater than the previous one', async () => {
@@ -685,7 +685,9 @@ describe('Events SDK', () => {
         }
       );
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService/events/InventoryAdjusted', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService/events/InventoryAdjusted', 'index.mdx'))).toBe(
+        true
+      );
     });
     it('writes an event to the given service. When a version is given for the service the event is added to that service version', async () => {
       await writeEventToService(
@@ -702,7 +704,7 @@ describe('Events SDK', () => {
         }
       );
       expect(
-        fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService/versioned/1.0.0/events/InventoryAdjusted', 'index.md'))
+        fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService/versioned/1.0.0/events/InventoryAdjusted', 'index.mdx'))
       ).toBe(true);
     });
     it('writes an event to the given service. When a version is the latest the event is added to the latest version of the service', async () => {
@@ -719,7 +721,7 @@ describe('Events SDK', () => {
           version: 'latest',
         }
       );
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService//events/InventoryAdjusted', 'index.md'))).toBe(
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService//events/InventoryAdjusted', 'index.mdx'))).toBe(
         true
       );
     });
@@ -735,11 +737,11 @@ describe('Events SDK', () => {
         markdown: '# Hello world',
       });
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'events/InventoryAdjusted', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'events/InventoryAdjusted', 'index.mdx'))).toBe(true);
 
       await rmEvent('/InventoryAdjusted');
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'events/InventoryAdjusted', 'index.md'))).toBe(false);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'events/InventoryAdjusted', 'index.mdx'))).toBe(false);
     });
   });
 
@@ -753,11 +755,11 @@ describe('Events SDK', () => {
         markdown: '# Hello world',
       });
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'events/InventoryAdjusted', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'events/InventoryAdjusted', 'index.mdx'))).toBe(true);
 
       await rmEventById('InventoryAdjusted');
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'events/InventoryAdjusted', 'index.md'))).toBe(false);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'events/InventoryAdjusted', 'index.mdx'))).toBe(false);
     });
 
     it('removes and event and all files in that event', async () => {
@@ -771,11 +773,11 @@ describe('Events SDK', () => {
 
       fs.writeFileSync(path.join(CATALOG_PATH, 'events/InventoryAdjusted', 'schema.json'), 'SCHEMA!');
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'events/InventoryAdjusted', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'events/InventoryAdjusted', 'index.mdx'))).toBe(true);
 
       await rmEventById('InventoryAdjusted');
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'events/InventoryAdjusted', 'index.md'))).toBe(false);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'events/InventoryAdjusted', 'index.mdx'))).toBe(false);
       expect(fs.existsSync(path.join(CATALOG_PATH, 'events/InventoryAdjusted', 'schema.json'))).toBe(false);
     });
 
@@ -790,11 +792,11 @@ describe('Events SDK', () => {
 
       fs.writeFileSync(path.join(CATALOG_PATH, 'events/InventoryAdjusted', 'schema.json'), 'SCHEMA!');
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'events/InventoryAdjusted', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'events/InventoryAdjusted', 'index.mdx'))).toBe(true);
 
       await rmEventById('InventoryAdjusted', '0.0.1', true);
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'events/InventoryAdjusted', 'index.md'))).toBe(false);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'events/InventoryAdjusted', 'index.mdx'))).toBe(false);
       expect(fs.existsSync(path.join(CATALOG_PATH, 'events/InventoryAdjusted', 'schema.json'))).toBe(true);
     });
 
@@ -807,11 +809,11 @@ describe('Events SDK', () => {
         markdown: '# Hello world',
       });
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'events/InventoryAdjusted', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'events/InventoryAdjusted', 'index.mdx'))).toBe(true);
 
       await rmEventById('InventoryAdjusted', '0.0.1');
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'events/InventoryAdjusted', 'index.md'))).toBe(false);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'events/InventoryAdjusted', 'index.mdx'))).toBe(false);
     });
 
     it('if version is given, only removes that version and not any other versions of the event', async () => {
@@ -835,14 +837,14 @@ describe('Events SDK', () => {
         markdown: '# Hello world',
       });
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'events/InventoryAdjusted', 'index.md'))).toBe(true);
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'events/InventoryAdjusted/versioned/0.0.1', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'events/InventoryAdjusted', 'index.mdx'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'events/InventoryAdjusted/versioned/0.0.1', 'index.mdx'))).toBe(true);
 
       await rmEventById('InventoryAdjusted', '0.0.1');
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'events/InventoryAdjusted', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'events/InventoryAdjusted', 'index.mdx'))).toBe(true);
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'events/InventoryAdjusted/versioned/0.0.2', 'index.md'))).toBe(false);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'events/InventoryAdjusted/versioned/0.0.2', 'index.mdx'))).toBe(false);
     });
 
     describe('when events are within a service directory', () => {
@@ -860,12 +862,12 @@ describe('Events SDK', () => {
           }
         );
 
-        // expect(fs.existsSync(path.join(CATALOG_PATH, 'services/Inventory/events/InventoryAdjusted', 'index.md'))).toBe(true);
-        expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService/events/InventoryAdjusted', 'index.md'))).toBe(
+        // expect(fs.existsSync(path.join(CATALOG_PATH, 'services/Inventory/events/InventoryAdjusted', 'index.mdx'))).toBe(true);
+        expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService/events/InventoryAdjusted', 'index.mdx'))).toBe(
           true
         );
         await rmEventById('InventoryAdjusted');
-        expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService/events/InventoryAdjusted', 'index.md'))).toBe(
+        expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService/events/InventoryAdjusted', 'index.mdx'))).toBe(
           false
         );
       });
@@ -901,20 +903,24 @@ describe('Events SDK', () => {
           }
         );
 
-        expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService/events/InventoryAdjusted', 'index.md'))).toBe(
+        expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService/events/InventoryAdjusted', 'index.mdx'))).toBe(
           true
         );
         expect(
-          fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService/events/InventoryAdjusted/versioned/0.0.1', 'index.md'))
+          fs.existsSync(
+            path.join(CATALOG_PATH, 'services/InventoryService/events/InventoryAdjusted/versioned/0.0.1', 'index.mdx')
+          )
         ).toBe(true);
 
         await rmEventById('InventoryAdjusted', '0.0.1');
 
-        expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService/events/InventoryAdjusted', 'index.md'))).toBe(
+        expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService/events/InventoryAdjusted', 'index.mdx'))).toBe(
           true
         );
         expect(
-          fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService/events/InventoryAdjusted/versioned/0.0.1', 'index.md'))
+          fs.existsSync(
+            path.join(CATALOG_PATH, 'services/InventoryService/events/InventoryAdjusted/versioned/0.0.1', 'index.mdx')
+          )
         ).toBe(false);
       });
     });
@@ -935,9 +941,9 @@ describe('Events SDK', () => {
 
       await versionEvent('InventoryAdjusted');
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'events/InventoryAdjusted/versioned/0.0.2', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'events/InventoryAdjusted/versioned/0.0.2', 'index.mdx'))).toBe(true);
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'events/InventoryAdjusted', 'index.md'))).toBe(false);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'events/InventoryAdjusted', 'index.mdx'))).toBe(false);
     });
     it('adds the given event to the versioned directory and all files that are associated to it', async () => {
       await writeEvent({
@@ -953,11 +959,11 @@ describe('Events SDK', () => {
 
       await versionEvent('InventoryAdjusted');
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'events/InventoryAdjusted/versioned/0.0.2', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'events/InventoryAdjusted/versioned/0.0.2', 'index.mdx'))).toBe(true);
 
       expect(fs.existsSync(path.join(CATALOG_PATH, 'events/InventoryAdjusted/versioned/0.0.2', 'schema.json'))).toBe(true);
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'events/InventoryAdjusted', 'index.md'))).toBe(false);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'events/InventoryAdjusted', 'index.mdx'))).toBe(false);
 
       expect(fs.existsSync(path.join(CATALOG_PATH, 'events/InventoryAdjusted', 'schema.json'))).toBe(false);
     });
@@ -978,9 +984,11 @@ describe('Events SDK', () => {
         await versionEvent('InventoryAdjusted');
 
         expect(
-          fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService/events/InventoryAdjusted/versioned/0.0.2', 'index.md'))
+          fs.existsSync(
+            path.join(CATALOG_PATH, 'services/InventoryService/events/InventoryAdjusted/versioned/0.0.2', 'index.mdx')
+          )
         ).toBe(true);
-        expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService/events/InventoryAdjusted', 'index.md'))).toBe(
+        expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService/events/InventoryAdjusted', 'index.mdx'))).toBe(
           false
         );
       });
@@ -1005,7 +1013,9 @@ describe('Events SDK', () => {
         await versionEvent('InventoryAdjusted');
 
         expect(
-          fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService/events/InventoryAdjusted/versioned/0.0.2', 'index.md'))
+          fs.existsSync(
+            path.join(CATALOG_PATH, 'services/InventoryService/events/InventoryAdjusted/versioned/0.0.2', 'index.mdx')
+          )
         ).toBe(true);
 
         expect(
@@ -1014,7 +1024,7 @@ describe('Events SDK', () => {
           )
         ).toBe(true);
 
-        expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService/events/InventoryAdjusted', 'index.md'))).toBe(
+        expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService/events/InventoryAdjusted', 'index.mdx'))).toBe(
           false
         );
 

--- a/src/test/queries.test.ts
+++ b/src/test/queries.test.ts
@@ -504,7 +504,7 @@ describe('Queries SDK', () => {
 
       const query = await getQuery('GetOrder');
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'queries/GetOrder', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'queries/GetOrder', 'index.mdx'))).toBe(true);
 
       expect(query).toEqual({
         id: 'GetOrder',
@@ -527,7 +527,7 @@ describe('Queries SDK', () => {
         { path: '/Inventory/GetOrder' }
       );
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'queries/Inventory/GetOrder', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'queries/Inventory/GetOrder', 'index.mdx'))).toBe(true);
     });
 
     it('throws an error when trying to write an query that already exists', async () => {
@@ -577,7 +577,7 @@ describe('Queries SDK', () => {
 
       const query = await getQuery('GetOrder');
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'queries/GetOrder', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'queries/GetOrder', 'index.mdx'))).toBe(true);
       expect(query.markdown).toBe('Overridden content');
     });
 
@@ -606,8 +606,8 @@ describe('Queries SDK', () => {
         expect(query.version).toBe('1.0.0');
         expect(query.markdown).toBe('New');
 
-        expect(fs.existsSync(path.join(CATALOG_PATH, 'queries/GetOrder/versioned/0.0.1', 'index.md'))).toBe(true);
-        expect(fs.existsSync(path.join(CATALOG_PATH, 'queries/GetOrder', 'index.md'))).toBe(true);
+        expect(fs.existsSync(path.join(CATALOG_PATH, 'queries/GetOrder/versioned/0.0.1', 'index.mdx'))).toBe(true);
+        expect(fs.existsSync(path.join(CATALOG_PATH, 'queries/GetOrder', 'index.mdx'))).toBe(true);
       });
 
       it('throws an error when trying to write a query and versionExistingContent is true and the new version number is not greater than the previous one', async () => {
@@ -653,7 +653,7 @@ describe('Queries SDK', () => {
         }
       );
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService/queries/GetOrder', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService/queries/GetOrder', 'index.mdx'))).toBe(true);
     });
     it('writes an query to the given service. When a version is given for the service the query is added to that service version', async () => {
       await writeQueryToService(
@@ -670,7 +670,7 @@ describe('Queries SDK', () => {
         }
       );
       expect(
-        fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService/versioned/1.0.0/queries/GetOrder', 'index.md'))
+        fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService/versioned/1.0.0/queries/GetOrder', 'index.mdx'))
       ).toBe(true);
     });
     it('writes an query to the given service. When a version is the latest the query is added to the latest version of the service', async () => {
@@ -687,7 +687,7 @@ describe('Queries SDK', () => {
           version: 'latest',
         }
       );
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService//queries/GetOrder', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService//queries/GetOrder', 'index.mdx'))).toBe(true);
     });
   });
 
@@ -701,11 +701,11 @@ describe('Queries SDK', () => {
         markdown: '# Hello world',
       });
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'queries/GetOrder', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'queries/GetOrder', 'index.mdx'))).toBe(true);
 
       await rmQuery('/GetOrder');
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'queries/GetOrder', 'index.md'))).toBe(false);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'queries/GetOrder', 'index.mdx'))).toBe(false);
     });
   });
 
@@ -719,11 +719,11 @@ describe('Queries SDK', () => {
         markdown: '# Hello world',
       });
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'queries/GetOrder', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'queries/GetOrder', 'index.mdx'))).toBe(true);
 
       await rmQueryById('GetOrder');
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'queries/GetOrder', 'index.md'))).toBe(false);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'queries/GetOrder', 'index.mdx'))).toBe(false);
     });
 
     it('removes a query and all files in that query', async () => {
@@ -737,11 +737,11 @@ describe('Queries SDK', () => {
 
       fs.writeFileSync(path.join(CATALOG_PATH, 'queries/GetOrder', 'schema.json'), 'SCHEMA!');
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'queries/GetOrder', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'queries/GetOrder', 'index.mdx'))).toBe(true);
 
       await rmQueryById('GetOrder');
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'queries/GetOrder', 'index.md'))).toBe(false);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'queries/GetOrder', 'index.mdx'))).toBe(false);
       expect(fs.existsSync(path.join(CATALOG_PATH, 'queries/GetOrder', 'schema.json'))).toBe(false);
     });
 
@@ -756,11 +756,11 @@ describe('Queries SDK', () => {
 
       fs.writeFileSync(path.join(CATALOG_PATH, 'queries/GetOrder', 'schema.json'), 'SCHEMA!');
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'queries/GetOrder', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'queries/GetOrder', 'index.mdx'))).toBe(true);
 
       await rmQueryById('GetOrder', '0.0.1', true);
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'queries/GetOrder', 'index.md'))).toBe(false);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'queries/GetOrder', 'index.mdx'))).toBe(false);
       expect(fs.existsSync(path.join(CATALOG_PATH, 'queries/GetOrder', 'schema.json'))).toBe(true);
     });
 
@@ -773,11 +773,11 @@ describe('Queries SDK', () => {
         markdown: '# Hello world',
       });
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'queries/GetOrder', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'queries/GetOrder', 'index.mdx'))).toBe(true);
 
       await rmQueryById('GetOrder', '0.0.1');
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'queries/GetOrder', 'index.md'))).toBe(false);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'queries/GetOrder', 'index.mdx'))).toBe(false);
     });
 
     it('if version is given, only removes that version and not any other versions of the query', async () => {
@@ -801,14 +801,14 @@ describe('Queries SDK', () => {
         markdown: '# Hello world',
       });
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'queries/GetOrder', 'index.md'))).toBe(true);
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'queries/GetOrder/versioned/0.0.1', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'queries/GetOrder', 'index.mdx'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'queries/GetOrder/versioned/0.0.1', 'index.mdx'))).toBe(true);
 
       await rmQueryById('GetOrder', '0.0.1');
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'queries/GetOrder', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'queries/GetOrder', 'index.mdx'))).toBe(true);
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'queries/GetOrder/versioned/0.0.2', 'index.md'))).toBe(false);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'queries/GetOrder/versioned/0.0.2', 'index.mdx'))).toBe(false);
     });
 
     describe('when queries are within a service directory', () => {
@@ -826,10 +826,10 @@ describe('Queries SDK', () => {
           }
         );
 
-        // expect(fs.existsSync(path.join(CATALOG_PATH, 'services/Inventory/queries/GetOrder', 'index.md'))).toBe(true);
-        expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService/queries/GetOrder', 'index.md'))).toBe(true);
+        // expect(fs.existsSync(path.join(CATALOG_PATH, 'services/Inventory/queries/GetOrder', 'index.mdx'))).toBe(true);
+        expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService/queries/GetOrder', 'index.mdx'))).toBe(true);
         await rmQueryById('GetOrder');
-        expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService/queries/GetOrder', 'index.md'))).toBe(false);
+        expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService/queries/GetOrder', 'index.mdx'))).toBe(false);
       });
 
       it('if version is given, only removes that version and not any other versions of the query', async () => {
@@ -863,16 +863,16 @@ describe('Queries SDK', () => {
           }
         );
 
-        expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService/queries/GetOrder', 'index.md'))).toBe(true);
+        expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService/queries/GetOrder', 'index.mdx'))).toBe(true);
         expect(
-          fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService/queries/GetOrder/versioned/0.0.1', 'index.md'))
+          fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService/queries/GetOrder/versioned/0.0.1', 'index.mdx'))
         ).toBe(true);
 
         await rmQueryById('GetOrder', '0.0.1');
 
-        expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService/queries/GetOrder', 'index.md'))).toBe(true);
+        expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService/queries/GetOrder', 'index.mdx'))).toBe(true);
         expect(
-          fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService/queries/GetOrder/versioned/0.0.1', 'index.md'))
+          fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService/queries/GetOrder/versioned/0.0.1', 'index.mdx'))
         ).toBe(false);
       });
     });
@@ -893,9 +893,9 @@ describe('Queries SDK', () => {
 
       await versionQuery('GetOrder');
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'queries/GetOrder/versioned/0.0.2', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'queries/GetOrder/versioned/0.0.2', 'index.mdx'))).toBe(true);
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'queries/GetOrder', 'index.md'))).toBe(false);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'queries/GetOrder', 'index.mdx'))).toBe(false);
     });
     it('adds the given query to the versioned directory and all files that are associated to it', async () => {
       await writeQuery({
@@ -911,11 +911,11 @@ describe('Queries SDK', () => {
 
       await versionQuery('GetOrder');
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'queries/GetOrder/versioned/0.0.2', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'queries/GetOrder/versioned/0.0.2', 'index.mdx'))).toBe(true);
 
       expect(fs.existsSync(path.join(CATALOG_PATH, 'queries/GetOrder/versioned/0.0.2', 'schema.json'))).toBe(true);
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'queries/GetOrder', 'index.md'))).toBe(false);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'queries/GetOrder', 'index.mdx'))).toBe(false);
 
       expect(fs.existsSync(path.join(CATALOG_PATH, 'queries/GetOrder', 'schema.json'))).toBe(false);
     });
@@ -936,9 +936,9 @@ describe('Queries SDK', () => {
         await versionQuery('GetOrder');
 
         expect(
-          fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService/queries/GetOrder/versioned/0.0.2', 'index.md'))
+          fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService/queries/GetOrder/versioned/0.0.2', 'index.mdx'))
         ).toBe(true);
-        expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService/queries/GetOrder', 'index.md'))).toBe(false);
+        expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService/queries/GetOrder', 'index.mdx'))).toBe(false);
       });
       it('adds the given query to the versioned directory and all files that are associated to it', async () => {
         await writeQueryToService(
@@ -958,14 +958,14 @@ describe('Queries SDK', () => {
         await versionQuery('GetOrder');
 
         expect(
-          fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService/queries/GetOrder/versioned/0.0.2', 'index.md'))
+          fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService/queries/GetOrder/versioned/0.0.2', 'index.mdx'))
         ).toBe(true);
 
         expect(
           fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService/queries/GetOrder/versioned/0.0.2', 'schema.json'))
         ).toBe(true);
 
-        expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService/queries/GetOrder', 'index.md'))).toBe(false);
+        expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService/queries/GetOrder', 'index.mdx'))).toBe(false);
 
         expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService/queries/GetOrder', 'schema.json'))).toBe(false);
       });

--- a/src/test/services.test.ts
+++ b/src/test/services.test.ts
@@ -425,7 +425,7 @@ describe('Services SDK', () => {
 
       const service = await getService('InventoryService');
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService', 'index.mdx'))).toBe(true);
 
       expect(service).toEqual({
         id: 'InventoryService',
@@ -448,7 +448,7 @@ describe('Services SDK', () => {
         { path: '/Inventory/InventoryService' }
       );
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'services/Inventory/InventoryService', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'services/Inventory/InventoryService', 'index.mdx'))).toBe(true);
     });
 
     it('messages written to a service are always unique', async () => {
@@ -544,7 +544,7 @@ describe('Services SDK', () => {
 
       const service = await getService('InventoryService');
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService', 'index.mdx'))).toBe(true);
       expect(service.markdown).toBe('Overridden content');
     });
 
@@ -573,8 +573,8 @@ describe('Services SDK', () => {
         expect(service.version).toBe('1.0.0');
         expect(service.markdown).toBe('New');
 
-        expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService/versioned/0.0.1', 'index.md'))).toBe(true);
-        expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService', 'index.md'))).toBe(true);
+        expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService/versioned/0.0.1', 'index.mdx'))).toBe(true);
+        expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService', 'index.mdx'))).toBe(true);
       });
 
       it('throws an error when trying to write a service and versionExistingContent is true and the new version number is not greater than the previous one', async () => {
@@ -624,7 +624,7 @@ describe('Services SDK', () => {
 
       const service = await getService('InventoryService', '0.0.1');
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService/versioned/0.0.1', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService/versioned/0.0.1', 'index.mdx'))).toBe(true);
 
       expect(service).toEqual({
         id: 'InventoryService',
@@ -651,7 +651,7 @@ describe('Services SDK', () => {
         }
       );
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'domains/Shopping/services/InventoryService', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'domains/Shopping/services/InventoryService', 'index.mdx'))).toBe(true);
     });
     it('writes a service to the given domain. When a version is given for the domain the service is added to that domain version', async () => {
       await writeServiceToDomain(
@@ -668,7 +668,7 @@ describe('Services SDK', () => {
         }
       );
       expect(
-        fs.existsSync(path.join(CATALOG_PATH, 'domains/Shopping/versioned/1.0.0/services/InventoryService', 'index.md'))
+        fs.existsSync(path.join(CATALOG_PATH, 'domains/Shopping/versioned/1.0.0/services/InventoryService', 'index.mdx'))
       ).toBe(true);
     });
     it('writes a service to the given domain. When a version is the latest the service is added to the latest version of the domain', async () => {
@@ -685,7 +685,7 @@ describe('Services SDK', () => {
           version: 'latest',
         }
       );
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'domains/Shopping/services/InventoryService/', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'domains/Shopping/services/InventoryService/', 'index.mdx'))).toBe(true);
     });
   });
 
@@ -701,8 +701,8 @@ describe('Services SDK', () => {
 
       await versionService('InventoryService');
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService/versioned/0.0.1', 'index.md'))).toBe(true);
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService', 'index.md'))).toBe(false);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService/versioned/0.0.1', 'index.mdx'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService', 'index.mdx'))).toBe(false);
     });
     it('adds the given service to the versioned directory and all files that are associated to it', async () => {
       await writeService({
@@ -718,9 +718,9 @@ describe('Services SDK', () => {
 
       await versionService('InventoryService');
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService/versioned/0.0.1', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService/versioned/0.0.1', 'index.mdx'))).toBe(true);
       expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService/versioned/0.0.1', 'schema.json'))).toBe(true);
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService', 'index.md'))).toBe(false);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService', 'index.mdx'))).toBe(false);
       expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService', 'schema.json'))).toBe(false);
     });
   });
@@ -735,11 +735,11 @@ describe('Services SDK', () => {
         markdown: '# Hello world',
       });
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService', 'index.mdx'))).toBe(true);
 
       await rmService('/InventoryService');
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService', 'index.md'))).toBe(false);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService', 'index.mdx'))).toBe(false);
     });
 
     it('removes all files with that service directory when the service is deleted', async () => {
@@ -754,11 +754,11 @@ describe('Services SDK', () => {
       // add random file
       fs.writeFileSync(path.join(CATALOG_PATH, 'services/InventoryService', 'schema.json'), 'dummy-data');
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService', 'index.mdx'))).toBe(true);
 
       await rmService('/InventoryService');
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService', 'index.md'))).toBe(false);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService', 'index.mdx'))).toBe(false);
       expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService', 'schema.json'))).toBe(false);
     });
   });
@@ -773,11 +773,11 @@ describe('Services SDK', () => {
         markdown: '# Hello world',
       });
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService', 'index.mdx'))).toBe(true);
 
       await rmServiceById('InventoryService');
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService', 'index.md'))).toBe(false);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService', 'index.mdx'))).toBe(false);
     });
 
     it('removes all files with that service directory when the service is deleted by id', async () => {
@@ -792,11 +792,11 @@ describe('Services SDK', () => {
       // add random file
       fs.writeFileSync(path.join(CATALOG_PATH, 'services/InventoryService', 'schema.json'), 'dummy-data');
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService', 'index.mdx'))).toBe(true);
 
       await rmServiceById('InventoryService');
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService', 'index.md'))).toBe(false);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService', 'index.mdx'))).toBe(false);
       expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService', 'schema.json'))).toBe(false);
     });
 
@@ -809,11 +809,11 @@ describe('Services SDK', () => {
         markdown: '# Hello world',
       });
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService', 'index.mdx'))).toBe(true);
 
       await rmServiceById('InventoryService', '0.0.1');
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService', 'index.md'))).toBe(false);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService', 'index.mdx'))).toBe(false);
     });
 
     it('if version is given, only removes that version and not any other versions of the service', async () => {
@@ -837,14 +837,14 @@ describe('Services SDK', () => {
         markdown: '# Hello world',
       });
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService', 'index.md'))).toBe(true);
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService/versioned/0.0.1', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService', 'index.mdx'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService/versioned/0.0.1', 'index.mdx'))).toBe(true);
 
       await rmServiceById('InventoryService', '0.0.1');
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService', 'index.md'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService', 'index.mdx'))).toBe(true);
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryAdjusted/versioned/0.0.2', 'index.md'))).toBe(false);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryAdjusted/versioned/0.0.2', 'index.mdx'))).toBe(false);
     });
 
     describe('when services are within a domain directory', () => {
@@ -860,11 +860,11 @@ describe('Services SDK', () => {
           { id: 'Shopping' }
         );
 
-        expect(fs.existsSync(path.join(CATALOG_PATH, 'domains/Shopping/services/InventoryService', 'index.md'))).toBe(true);
+        expect(fs.existsSync(path.join(CATALOG_PATH, 'domains/Shopping/services/InventoryService', 'index.mdx'))).toBe(true);
 
         await rmServiceById('InventoryService');
 
-        expect(fs.existsSync(path.join(CATALOG_PATH, 'domains/Shopping/services/InventoryService', 'index.md'))).toBe(false);
+        expect(fs.existsSync(path.join(CATALOG_PATH, 'domains/Shopping/services/InventoryService', 'index.mdx'))).toBe(false);
       });
 
       it('removes a service from eventcatalog by id and version', async () => {
@@ -879,11 +879,11 @@ describe('Services SDK', () => {
           { id: 'Shopping' }
         );
 
-        expect(fs.existsSync(path.join(CATALOG_PATH, 'domains/Shopping/services/InventoryService', 'index.md'))).toBe(true);
+        expect(fs.existsSync(path.join(CATALOG_PATH, 'domains/Shopping/services/InventoryService', 'index.mdx'))).toBe(true);
 
         await rmServiceById('InventoryService', '0.0.1');
 
-        expect(fs.existsSync(path.join(CATALOG_PATH, 'domains/Shopping/services/InventoryService', 'index.md'))).toBe(false);
+        expect(fs.existsSync(path.join(CATALOG_PATH, 'domains/Shopping/services/InventoryService', 'index.mdx'))).toBe(false);
       });
     });
   });
@@ -1105,7 +1105,7 @@ describe('Services SDK', () => {
         });
 
         //expect file where is was
-        expect(fs.existsSync(path.join(CATALOG_PATH, 'domains/Shopping/services/InventoryService', 'index.md'))).toBe(true);
+        expect(fs.existsSync(path.join(CATALOG_PATH, 'domains/Shopping/services/InventoryService', 'index.mdx'))).toBe(true);
       });
 
       it('takes an existing event and adds it to the receives of an existing service', async () => {


### PR DESCRIPTION
Introducing a breaking change moving from `md` files to `mdx` files.

We have some changes coming to EventCatalog to improve the core of the project, this requires us to move to `mdx` files. EventCatalog will change the files for you, so Eventcatalog won't be breaking, but the SDK will be.

