### PR TITLE
fix(sdk): writing messages to services now works correctly

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -1,10 +1,11 @@
 import fs from 'node:fs/promises';
-import { join } from 'node:path';
+import { join, dirname } from 'node:path';
 import { findFileById } from './internal/utils';
 import type { Event } from './types';
 import {
   addFileToResource,
   getResource,
+  getResourcePath,
   getResources,
   rmResourceById,
   versionResource,
@@ -141,10 +142,15 @@ export const writeEvent =
 export const writeEventToService =
   (directory: string) =>
   async (event: Event, service: { id: string; version?: string }, options: { path: string } = { path: '' }) => {
+    const resourcePath = await getResourcePath(directory, service.id, service.version);
+    if (!resourcePath) {
+      throw new Error('Service not found');
+    }
+
     let pathForEvent =
       service.version && service.version !== 'latest'
-        ? `/${service.id}/versioned/${service.version}/events`
-        : `/${service.id}/events`;
+        ? `${resourcePath.directory}/versioned/${service.version}/events`
+        : `${resourcePath.directory}/events`;
     pathForEvent = join(pathForEvent, event.id);
     await writeResource(directory, { ...event }, { ...options, path: pathForEvent, type: 'event' });
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -117,7 +117,7 @@ export default (path: string) => {
      * @param options - Optional options to write the event
      *
      */
-    writeEventToService: writeEventToService(join(path, 'services')),
+    writeEventToService: writeEventToService(join(path)),
     /**
      * Remove an event to EventCatalog (modeled on the standard POSIX rm utility)
      *
@@ -197,7 +197,7 @@ export default (path: string) => {
      * @param options - Optional options to write the command
      *
      */
-    writeCommandToService: writeCommandToService(join(path, 'services')),
+    writeCommandToService: writeCommandToService(join(path)),
 
     /**
      * Remove an command to EventCatalog (modeled on the standard POSIX rm utility)
@@ -278,7 +278,7 @@ export default (path: string) => {
      * @param options - Optional options to write the query
      *
      */
-    writeQueryToService: writeQueryToService(join(path, 'services')),
+    writeQueryToService: writeQueryToService(join(path)),
     /**
      * Remove an query to EventCatalog (modeled on the standard POSIX rm utility)
      *

--- a/src/internal/resources.ts
+++ b/src/internal/resources.ts
@@ -15,7 +15,7 @@ export const versionResource = async (catalogDir: string, id: string) => {
   const matchedFiles = await searchFilesForId(files, id);
 
   if (matchedFiles.length === 0) {
-    throw new Error(`No event found with id: ${id}`);
+    throw new Error(`No resource found with id: ${id}`);
   }
 
   // Event that is in the route of the project
@@ -117,6 +117,17 @@ export const getResource = async (
     ...data,
     markdown: content.trim(),
   } as Resource;
+};
+
+export const getResourcePath = async (catalogDir: string, id: string, version?: string) => {
+  const file = await findFileById(catalogDir, id, version);
+  if (!file) return;
+
+  return {
+    fullPath: file,
+    relativePath: file.replace(catalogDir, ''),
+    directory: dirname(file.replace(catalogDir, '')),
+  };
 };
 
 export const getResources = async (

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -5,6 +5,7 @@ import type { Query } from './types';
 import {
   addFileToResource,
   getResource,
+  getResourcePath,
   getResources,
   rmResourceById,
   versionResource,
@@ -139,10 +140,14 @@ export const getQueries =
 export const writeQueryToService =
   (directory: string) =>
   async (query: Query, service: { id: string; version?: string }, options: { path: string } = { path: '' }) => {
+    const resourcePath = await getResourcePath(directory, service.id, service.version);
+    if (!resourcePath) {
+      throw new Error('Service not found');
+    }
     let pathForQuery =
       service.version && service.version !== 'latest'
-        ? `/${service.id}/versioned/${service.version}/queries`
-        : `/${service.id}/queries`;
+        ? `${resourcePath.directory}/versioned/${service.version}/queries`
+        : `${resourcePath.directory}/queries`;
     pathForQuery = join(pathForQuery, query.id);
     await writeResource(directory, { ...query }, { ...options, path: pathForQuery, type: 'query' });
   };

--- a/src/test/commands.test.ts
+++ b/src/test/commands.test.ts
@@ -17,6 +17,7 @@ const {
   addSchemaToCommand,
   commandHasVersion,
   writeCommandToService,
+  writeService,
 } = utils(CATALOG_PATH);
 
 // clean the catalog before each test
@@ -52,6 +53,13 @@ describe('Commands SDK', () => {
     });
 
     it('returns the given command id from EventCatalog and the latest version when no version is given and the command is inside a services folder,', async () => {
+      await writeService({
+        id: 'Inventory',
+        name: 'Inventory Service',
+        version: '0.0.1',
+        summary: 'Service that handles inventory',
+        markdown: '# Hello world',
+      });
       await writeCommandToService(
         {
           id: 'UpdateInventory',
@@ -396,6 +404,14 @@ describe('Commands SDK', () => {
 
   describe('writeCommandToService', () => {
     it('writes a command to the given service. When no version if given for the command the service is added to the latest service', async () => {
+      await writeService({
+        id: 'Inventory',
+        name: 'Inventory Service',
+        version: '0.0.1',
+        summary: 'Service that handles inventory',
+        markdown: '# Hello world',
+      });
+
       await writeCommandToService(
         {
           id: 'UpdateInventory',
@@ -404,16 +420,20 @@ describe('Commands SDK', () => {
           summary: 'This is a summary',
           markdown: '# Hello world',
         },
-        {
-          id: 'InventoryService',
-        }
+        { id: 'Inventory' }
       );
 
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService/commands/UpdateInventory', 'index.mdx'))).toBe(
-        true
-      );
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'services/Inventory/commands/UpdateInventory', 'index.mdx'))).toBe(true);
     });
     it('writes a command to the given service. When a version is given for the command the service is added to that service version', async () => {
+      await writeService({
+        id: 'Inventory',
+        name: 'Inventory Service',
+        version: '1.0.0',
+        summary: 'Service that handles inventory',
+        markdown: '# Hello world',
+      });
+
       await writeCommandToService(
         {
           id: 'UpdateInventory',
@@ -422,16 +442,21 @@ describe('Commands SDK', () => {
           summary: 'This is a summary',
           markdown: '# Hello world',
         },
-        {
-          id: 'InventoryService',
-          version: '1.0.0',
-        }
+        { id: 'Inventory', version: '1.0.0' }
       );
       expect(
-        fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService/versioned/1.0.0/commands/UpdateInventory', 'index.mdx'))
+        fs.existsSync(path.join(CATALOG_PATH, 'services/Inventory/versioned/1.0.0/commands/UpdateInventory', 'index.mdx'))
       ).toBe(true);
     });
     it('writes a command to the given service. When a version is the latest the command is added to the latest version of the service', async () => {
+      await writeService({
+        id: 'Inventory',
+        name: 'Inventory Service',
+        version: '0.0.1',
+        summary: 'Service that handles inventory',
+        markdown: '# Hello world',
+      });
+
       await writeCommandToService(
         {
           id: 'UpdateInventory',
@@ -440,14 +465,9 @@ describe('Commands SDK', () => {
           summary: 'This is a summary',
           markdown: '# Hello world',
         },
-        {
-          id: 'InventoryService',
-          version: 'latest',
-        }
+        { id: 'Inventory', version: 'latest' }
       );
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService/commands/UpdateInventory', 'index.mdx'))).toBe(
-        true
-      );
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'services/Inventory/commands/UpdateInventory', 'index.mdx'))).toBe(true);
     });
   });
 
@@ -572,6 +592,14 @@ describe('Commands SDK', () => {
 
     describe('when commands are within a service directory', () => {
       it('removes an command from eventcatalog by id', async () => {
+        await writeService({
+          id: 'Inventory',
+          name: 'Inventory Service',
+          version: '0.0.1',
+          summary: 'Service that handles inventory',
+          markdown: '# Hello world',
+        });
+
         await writeCommandToService(
           {
             id: 'UpdateInventory',
@@ -591,6 +619,14 @@ describe('Commands SDK', () => {
       });
 
       it('if version is given, only removes that version and not any other versions of the command', async () => {
+        await writeService({
+          id: 'Inventory',
+          name: 'Inventory Service',
+          version: '0.0.1',
+          summary: 'Service that handles inventory',
+          markdown: '# Hello world',
+        });
+
         await writeCommandToService(
           {
             id: 'UpdateInventory',
@@ -676,6 +712,14 @@ describe('Commands SDK', () => {
 
     describe('when commands are within a service directory', () => {
       it('adds the given command to the versioned directory and removes itself from the root', async () => {
+        await writeService({
+          id: 'Inventory',
+          name: 'Inventory Service',
+          version: '0.0.1',
+          summary: 'Service that handles inventory',
+          markdown: '# Hello world',
+        });
+
         await writeCommandToService(
           {
             id: 'UpdateInventory',
@@ -699,6 +743,14 @@ describe('Commands SDK', () => {
         expect(fs.existsSync(path.join(CATALOG_PATH, 'services/Inventory/commands/UpdateInventory', 'index.mdx'))).toBe(false);
       });
       it('adds the given command to the versioned directory and all files that are associated to it', async () => {
+        await writeService({
+          id: 'Inventory',
+          name: 'Inventory Service',
+          version: '0.0.1',
+          summary: 'Service that handles inventory',
+          markdown: '# Hello world',
+        });
+
         await writeCommandToService(
           {
             id: 'UpdateInventory',
@@ -804,6 +856,14 @@ describe('Commands SDK', () => {
       it('takes a given file and writes it to the location of the given command', async () => {
         const file = { content: 'hello', fileName: 'test.txt' };
 
+        await writeService({
+          id: 'Inventory',
+          name: 'Inventory Service',
+          version: '0.0.1',
+          summary: 'Service that handles inventory',
+          markdown: '# Hello world',
+        });
+
         await writeCommandToService(
           {
             id: 'UpdateInventory',
@@ -822,6 +882,14 @@ describe('Commands SDK', () => {
 
       it('takes a given file and version and writes the file to the correct location', async () => {
         const file = { content: 'hello', fileName: 'test.txt' };
+
+        await writeService({
+          id: 'Inventory',
+          name: 'Inventory Service',
+          version: '0.0.1',
+          summary: 'Service that handles inventory',
+          markdown: '# Hello world',
+        });
 
         await writeCommandToService(
           {
@@ -925,6 +993,14 @@ describe('Commands SDK', () => {
         }`;
         const file = { schema, fileName: 'schema.json' };
 
+        await writeService({
+          id: 'Inventory',
+          name: 'Inventory Service',
+          version: '0.0.1',
+          summary: 'Service that handles inventory',
+          markdown: '# Hello world',
+        });
+
         await writeCommandToService(
           {
             id: 'UpdateInventory',
@@ -954,6 +1030,14 @@ describe('Commands SDK', () => {
           }
         }`;
         const file = { schema, fileName: 'schema.json' };
+
+        await writeService({
+          id: 'Inventory',
+          name: 'Inventory Service',
+          version: '0.0.1',
+          summary: 'Service that handles inventory',
+          markdown: '# Hello world',
+        });
 
         await writeCommandToService(
           {

--- a/src/test/events.test.ts
+++ b/src/test/events.test.ts
@@ -18,6 +18,7 @@ const {
   addSchemaToEvent,
   eventHasVersion,
   writeServiceToDomain,
+  writeService,
 } = utils(CATALOG_PATH);
 
 // clean the catalog before each test
@@ -357,6 +358,38 @@ describe('Events SDK', () => {
           markdown: '# Hello world',
         });
       });
+
+      it('writes the event to the correct folder path', async () => {
+        await writeServiceToDomain(
+          {
+            id: 'InventoryService',
+            name: 'Inventory Service',
+            version: '0.0.1',
+            summary: 'Service tat handles the inventory',
+            markdown: '# Hello world',
+          },
+          { id: 'Shopping' }
+        );
+
+        await writeEventToService(
+          {
+            id: 'InventoryAdjusted',
+            name: 'Inventory Adjusted',
+            version: '0.0.1',
+            summary: 'This is a summary',
+            markdown: '# Hello world',
+          },
+          {
+            id: 'InventoryService',
+          }
+        );
+
+        const files = await fs.readdirSync(
+          path.join(CATALOG_PATH, 'domains/Shopping/services/InventoryService/events/InventoryAdjusted')
+        );
+
+        expect(files).toEqual(['index.mdx']);
+      });
     });
   });
 
@@ -678,6 +711,14 @@ describe('Events SDK', () => {
 
   describe('writeEventToService', () => {
     it('writes an event to the given service. When no version if given for the service the event is added to the latest service', async () => {
+      await writeService({
+        id: 'InventoryService',
+        name: 'Inventory Service',
+        version: '0.0.1',
+        summary: 'This is a summary',
+        markdown: '# Hello world',
+      });
+
       await writeEventToService(
         {
           id: 'InventoryAdjusted',
@@ -696,6 +737,13 @@ describe('Events SDK', () => {
       );
     });
     it('writes an event to the given service. When a version is given for the service the event is added to that service version', async () => {
+      await writeService({
+        id: 'InventoryService',
+        name: 'Inventory Service',
+        version: '1.0.0',
+        summary: 'This is a summary',
+        markdown: '# Hello world',
+      });
       await writeEventToService(
         {
           id: 'InventoryAdjusted',
@@ -714,6 +762,14 @@ describe('Events SDK', () => {
       ).toBe(true);
     });
     it('writes an event to the given service. When a version is the latest the event is added to the latest version of the service', async () => {
+      await writeService({
+        id: 'InventoryService',
+        name: 'Inventory Service',
+        version: '1.0.0',
+        summary: 'This is a summary',
+        markdown: '# Hello world',
+      });
+
       await writeEventToService(
         {
           id: 'InventoryAdjusted',
@@ -855,6 +911,13 @@ describe('Events SDK', () => {
 
     describe('when events are within a service directory', () => {
       it('removes an event from EventCatalog by id', async () => {
+        await writeService({
+          id: 'InventoryService',
+          name: 'Inventory Service',
+          version: '0.0.1',
+          summary: 'This is a summary',
+          markdown: '# Hello world',
+        });
         await writeEventToService(
           {
             id: 'InventoryAdjusted',
@@ -880,13 +943,19 @@ describe('Events SDK', () => {
 
       it('if version is given, only removes that version and not any other versions of the event', async () => {
         // write the first events
+        await writeService({
+          id: 'InventoryService',
+          name: 'Inventory Service',
+          version: '0.0.1',
+          summary: 'This is a summary',
+          markdown: '# Hello world',
+        });
         await writeEventToService(
           {
             id: 'InventoryAdjusted',
             name: 'Inventory Adjusted',
-            version: '0.0.1',
-            summary: 'This is a summary',
             markdown: '# Hello world',
+            version: '0.0.1',
           },
           {
             id: 'InventoryService',
@@ -976,6 +1045,14 @@ describe('Events SDK', () => {
 
     describe('when events are within a service directory', () => {
       it('adds the given event to the versioned directory and removes itself from the root', async () => {
+        await writeService({
+          id: 'InventoryService',
+          name: 'Inventory Service',
+          version: '0.0.1',
+          summary: 'This is a summary',
+          markdown: '# Hello world',
+        });
+
         await writeEventToService(
           {
             id: 'InventoryAdjusted',
@@ -999,6 +1076,14 @@ describe('Events SDK', () => {
         );
       });
       it('adds the given event to the versioned directory and all files that are associated to it', async () => {
+        await writeService({
+          id: 'InventoryService',
+          name: 'Inventory Service',
+          version: '0.0.1',
+          summary: 'This is a summary',
+          markdown: '# Hello world',
+        });
+
         await writeEventToService(
           {
             id: 'InventoryAdjusted',
@@ -1087,6 +1172,14 @@ describe('Events SDK', () => {
       it('takes a given file and writes it to the location of the given event', async () => {
         const file = { content: 'hello', fileName: 'test.txt' };
 
+        await writeService({
+          id: 'InventoryService',
+          name: 'Inventory Service',
+          version: '0.0.1',
+          summary: 'This is a summary',
+          markdown: '# Hello world',
+        });
+
         await writeEventToService(
           {
             id: 'InventoryAdjusted',
@@ -1107,6 +1200,14 @@ describe('Events SDK', () => {
 
       it('takes a given file and version and writes the file to the correct location', async () => {
         const file = { content: 'hello', fileName: 'test.txt' };
+
+        await writeService({
+          id: 'InventoryService',
+          name: 'Inventory Service',
+          version: '0.0.1',
+          summary: 'This is a summary',
+          markdown: '# Hello world',
+        });
 
         await writeEventToService(
           {
@@ -1210,6 +1311,14 @@ describe('Events SDK', () => {
         }`;
         const file = { schema, fileName: 'schema.json' };
 
+        await writeService({
+          id: 'InventoryService',
+          name: 'Inventory Service',
+          version: '0.0.1',
+          summary: 'This is a summary',
+          markdown: '# Hello world',
+        });
+
         await writeEventToService(
           {
             id: 'InventoryAdjusted',
@@ -1241,6 +1350,14 @@ describe('Events SDK', () => {
           }
         }`;
         const file = { schema, fileName: 'schema.json' };
+
+        await writeService({
+          id: 'InventoryService',
+          name: 'Inventory Service',
+          version: '0.0.1',
+          summary: 'This is a summary',
+          markdown: '# Hello world',
+        });
 
         await writeEventToService(
           {

--- a/src/test/queries.test.ts
+++ b/src/test/queries.test.ts
@@ -18,6 +18,8 @@ const {
   addSchemaToQuery,
   queryHasVersion,
   writeServiceToDomain,
+  writeService,
+  writeDomain,
 } = utils(CATALOG_PATH);
 
 // clean the catalog before each test
@@ -164,6 +166,14 @@ describe('Queries SDK', () => {
 
     describe('when queries are within a service that is within a domain', async () => {
       it('returns the given query id from EventCatalog and the latest version when no version is given,', async () => {
+        await writeDomain({
+          id: 'Shopping',
+          name: 'Shopping Domain',
+          version: '0.0.1',
+          summary: 'Domain that handles the shopping',
+          markdown: '# Hello world',
+        });
+
         await writeServiceToDomain(
           {
             id: 'InventoryService',
@@ -200,6 +210,22 @@ describe('Queries SDK', () => {
       });
 
       it('returns the given query id from EventCatalog and the latest version when no version is given and the query is inside a services folder,', async () => {
+        await writeService({
+          id: 'InventoryService',
+          name: 'Inventory Service',
+          version: '0.0.1',
+          summary: 'Service tat handles the inventory',
+          markdown: '# Hello world',
+        });
+
+        await writeDomain({
+          id: 'Shopping',
+          name: 'Shopping Domain',
+          version: '0.0.1',
+          summary: 'Domain that handles the shopping',
+          markdown: '# Hello world',
+        });
+
         await writeServiceToDomain(
           {
             id: 'InventoryService',
@@ -236,6 +262,14 @@ describe('Queries SDK', () => {
       });
 
       it('returns the given query id from EventCatalog and the requested version when a version is given,', async () => {
+        await writeService({
+          id: 'InventoryService',
+          name: 'Inventory Service',
+          version: '0.0.1',
+          summary: 'Service tat handles the inventory',
+          markdown: '# Hello world',
+        });
+
         await writeServiceToDomain(
           {
             id: 'InventoryService',
@@ -287,6 +321,14 @@ describe('Queries SDK', () => {
       });
 
       it('returns the latest version of the query if the version matches the latest version', async () => {
+        await writeService({
+          id: 'InventoryService',
+          name: 'Inventory Service',
+          version: '0.0.1',
+          summary: 'Service tat handles the inventory',
+          markdown: '# Hello world',
+        });
+
         await writeServiceToDomain(
           {
             id: 'InventoryService',
@@ -323,6 +365,14 @@ describe('Queries SDK', () => {
       });
 
       it('returns the version of the query even if the query does not match semver matching', async () => {
+        await writeService({
+          id: 'InventoryService',
+          name: 'Inventory Service',
+          version: '100',
+          summary: 'Service tat handles the inventory',
+          markdown: '# Hello world',
+        });
+
         await writeServiceToDomain(
           {
             id: 'InventoryService',
@@ -640,6 +690,14 @@ describe('Queries SDK', () => {
 
   describe('writeQueryToService', () => {
     it('writes an query to the given service. When no version if given for the service the query is added to the latest service', async () => {
+      await writeService({
+        id: 'InventoryService',
+        name: 'Inventory Service',
+        version: '0.0.1',
+        summary: 'Service that handles inventory',
+        markdown: '# Hello world',
+      });
+
       await writeQueryToService(
         {
           id: 'GetOrder',
@@ -656,6 +714,14 @@ describe('Queries SDK', () => {
       expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService/queries/GetOrder', 'index.mdx'))).toBe(true);
     });
     it('writes an query to the given service. When a version is given for the service the query is added to that service version', async () => {
+      await writeService({
+        id: 'InventoryService',
+        name: 'Inventory Service',
+        version: '1.0.0',
+        summary: 'Service that handles inventory',
+        markdown: '# Hello world',
+      });
+
       await writeQueryToService(
         {
           id: 'GetOrder',
@@ -674,6 +740,14 @@ describe('Queries SDK', () => {
       ).toBe(true);
     });
     it('writes an query to the given service. When a version is the latest the query is added to the latest version of the service', async () => {
+      await writeService({
+        id: 'InventoryService',
+        name: 'Inventory Service',
+        version: '0.0.1',
+        summary: 'Service that handles inventory',
+        markdown: '# Hello world',
+      });
+
       await writeQueryToService(
         {
           id: 'GetOrder',
@@ -687,7 +761,7 @@ describe('Queries SDK', () => {
           version: 'latest',
         }
       );
-      expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService//queries/GetOrder', 'index.mdx'))).toBe(true);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService/queries/GetOrder', 'index.mdx'))).toBe(true);
     });
   });
 
@@ -813,6 +887,14 @@ describe('Queries SDK', () => {
 
     describe('when queries are within a service directory', () => {
       it('removes an query from EventCatalog by id', async () => {
+        await writeService({
+          id: 'InventoryService',
+          name: 'Inventory Service',
+          version: '0.0.1',
+          summary: 'Service that handles inventory',
+          markdown: '# Hello world',
+        });
+
         await writeQueryToService(
           {
             id: 'GetOrder',
@@ -826,14 +908,20 @@ describe('Queries SDK', () => {
           }
         );
 
-        // expect(fs.existsSync(path.join(CATALOG_PATH, 'services/Inventory/queries/GetOrder', 'index.mdx'))).toBe(true);
         expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService/queries/GetOrder', 'index.mdx'))).toBe(true);
         await rmQueryById('GetOrder');
         expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService/queries/GetOrder', 'index.mdx'))).toBe(false);
       });
 
       it('if version is given, only removes that version and not any other versions of the query', async () => {
-        // write the first queries
+        await writeService({
+          id: 'InventoryService',
+          name: 'Inventory Service',
+          version: '0.0.1',
+          summary: 'Service that handles inventory',
+          markdown: '# Hello world',
+        });
+
         await writeQueryToService(
           {
             id: 'GetOrder',
@@ -849,7 +937,6 @@ describe('Queries SDK', () => {
 
         await versionQuery('GetOrder');
 
-        // Write the versioned query
         await writeQueryToService(
           {
             id: 'GetOrder',
@@ -922,6 +1009,14 @@ describe('Queries SDK', () => {
 
     describe('when queries are within a service directory', () => {
       it('adds the given query to the versioned directory and removes itself from the root', async () => {
+        await writeService({
+          id: 'InventoryService',
+          name: 'Inventory Service',
+          version: '0.0.1',
+          summary: 'Service that handles inventory',
+          markdown: '# Hello world',
+        });
+
         await writeQueryToService(
           {
             id: 'GetOrder',
@@ -941,6 +1036,14 @@ describe('Queries SDK', () => {
         expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService/queries/GetOrder', 'index.mdx'))).toBe(false);
       });
       it('adds the given query to the versioned directory and all files that are associated to it', async () => {
+        await writeService({
+          id: 'InventoryService',
+          name: 'Inventory Service',
+          version: '0.0.1',
+          summary: 'Service that handles inventory',
+          markdown: '# Hello world',
+        });
+
         await writeQueryToService(
           {
             id: 'GetOrder',
@@ -1018,6 +1121,14 @@ describe('Queries SDK', () => {
       it('takes a given file and writes it to the location of the given query', async () => {
         const file = { content: 'hello', fileName: 'test.txt' };
 
+        await writeService({
+          id: 'InventoryService',
+          name: 'Inventory Service',
+          version: '0.0.1',
+          summary: 'Service that handles inventory',
+          markdown: '# Hello world',
+        });
+
         await writeQueryToService(
           {
             id: 'GetOrder',
@@ -1037,6 +1148,14 @@ describe('Queries SDK', () => {
       it('takes a given file and version and writes the file to the correct location', async () => {
         const file = { content: 'hello', fileName: 'test.txt' };
 
+        await writeService({
+          id: 'InventoryService',
+          name: 'Inventory Service',
+          version: '0.0.1',
+          summary: 'Service that handles inventory',
+          markdown: '# Hello world',
+        });
+
         await writeQueryToService(
           {
             id: 'GetOrder',
@@ -1048,7 +1167,6 @@ describe('Queries SDK', () => {
           { id: 'InventoryService' }
         );
 
-        // version the query
         await versionQuery('GetOrder');
 
         await addFileToQuery('GetOrder', file, '0.0.1');
@@ -1139,6 +1257,14 @@ describe('Queries SDK', () => {
         }`;
         const file = { schema, fileName: 'schema.json' };
 
+        await writeService({
+          id: 'InventoryService',
+          name: 'Inventory Service',
+          version: '0.0.1',
+          summary: 'Service that handles inventory',
+          markdown: '# Hello world',
+        });
+
         await writeQueryToService(
           {
             id: 'GetOrder',
@@ -1169,6 +1295,14 @@ describe('Queries SDK', () => {
         }`;
         const file = { schema, fileName: 'schema.json' };
 
+        await writeService({
+          id: 'InventoryService',
+          name: 'Inventory Service',
+          version: '0.0.1',
+          summary: 'Service that handles inventory',
+          markdown: '# Hello world',
+        });
+
         await writeQueryToService(
           {
             id: 'GetOrder',
@@ -1180,7 +1314,6 @@ describe('Queries SDK', () => {
           { id: 'InventoryService' }
         );
 
-        // version the query
         await versionQuery('GetOrder');
 
         await addSchemaToQuery('GetOrder', file, '0.0.1');


### PR DESCRIPTION
Fixed a few issues

• writing messages to services now works with any folder structure 
   - Fixed issue where you could not write a message to a service if the service was within a domain
 • when writing messages to services, the service has to exist, previously you could write a message without a service, this is no longer the case.