### PR TITLE
fix(sdk): when getting files now uses cwd if it can

### DIFF
--- a/.changeset/tough-clouds-wink.md
+++ b/.changeset/tough-clouds-wink.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/sdk": patch
+---
+
+fix(sdk): fixed small bug when getting resources could return resources it should not

--- a/src/internal/utils.ts
+++ b/src/internal/utils.ts
@@ -1,8 +1,7 @@
-import { glob, globSync } from 'glob';
-import fs from 'node:fs/promises';
+import { globSync } from 'glob';
 import fsSync from 'node:fs';
-import { copy, copySync, CopyFilterAsync, CopyFilterSync } from 'fs-extra';
-import { join } from 'node:path';
+import { copy, CopyFilterAsync, CopyFilterSync } from 'fs-extra';
+import { join, dirname } from 'node:path';
 import matter from 'gray-matter';
 import { satisfies, validRange, valid } from 'semver';
 
@@ -55,7 +54,8 @@ export const findFileById = async (catalogDir: string, id: string, version?: str
 export const getFiles = async (pattern: string, ignore: string | string[] = '') => {
   try {
     const ignoreList = Array.isArray(ignore) ? ignore : [ignore];
-    const files = globSync(pattern, { ignore: ['node_modules/**', ...ignoreList] });
+    const baseDir = pattern.includes('**') ? pattern.split('**')[0] : dirname(pattern);
+    const files = globSync(pattern, { cwd: baseDir, ignore: ['node_modules/**', ...ignoreList] });
     return files;
   } catch (error) {
     throw new Error(`Error finding files: ${error}`);

--- a/src/test/eventcatalog.test.ts
+++ b/src/test/eventcatalog.test.ts
@@ -30,7 +30,7 @@ describe('EventCatalog', () => {
 
     it('should not include markdown if the includeMarkdown option is false', async () => {
       const dump = await dumpCatalog({ includeMarkdown: false });
-      expect(dump.resources.messages.events[0].markdown).toBeUndefined();
+      expect(dump.resources.messages?.events?.[0].markdown).toBeUndefined();
     });
 
     describe('domains', () => {
@@ -38,7 +38,7 @@ describe('EventCatalog', () => {
         const dump = await dumpCatalog();
         expect(dump.resources.domains).toHaveLength(3);
 
-        const domain1 = dump.resources.domains[0];
+        const domain1 = dump.resources.domains?.[0];
 
         expect(domain1).toEqual(
           expect.objectContaining({
@@ -70,7 +70,7 @@ describe('EventCatalog', () => {
         const dump = await dumpCatalog();
         expect(dump.resources.services).toHaveLength(6);
 
-        const service1 = dump.resources.services[0];
+        const service1 = dump.resources.services?.[0];
 
         expect(service1).toEqual(
           expect.objectContaining({
@@ -87,8 +87,8 @@ describe('EventCatalog', () => {
           })
         );
 
-        expect(service1.sends).toHaveLength(6);
-        expect(service1.receives).toHaveLength(5);
+        expect(service1?.sends).toHaveLength(6);
+        expect(service1?.receives).toHaveLength(5);
       });
     });
 
@@ -96,21 +96,21 @@ describe('EventCatalog', () => {
       describe('events', () => {
         it('returns a list of events from the catalog', async () => {
           const dump = await dumpCatalog();
-          expect(dump.resources.messages.events).toHaveLength(14);
+          expect(dump.resources.messages?.events).toHaveLength(14);
         });
       });
 
       describe('queries', () => {
         it('returns a list of queries from the catalog', async () => {
           const dump = await dumpCatalog();
-          expect(dump.resources.messages.queries).toHaveLength(5);
+          expect(dump.resources.messages?.queries).toHaveLength(5);
         });
       });
 
       describe('commands', () => {
         it('returns a list of commands from the catalog', async () => {
           const dump = await dumpCatalog();
-          expect(dump.resources.messages.commands).toHaveLength(8);
+          expect(dump.resources.messages?.commands).toHaveLength(8);
         });
       });
     });


### PR DESCRIPTION
Fixed an issue where the glob sync we ignoring anything in the ignored list, now uses CWD if it can.