### PR TITLE
feat(sdk): added backwards compatibility for md files

### DIFF
--- a/.changeset/good-days-rescue.md
+++ b/.changeset/good-days-rescue.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/sdk": patch
+---
+
+feat(sdk): added backwards compatibility for md files

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -113,7 +113,15 @@ export const getCommands =
  */
 export const writeCommand =
   (directory: string) =>
-  async (command: Command, options: { path?: string; override?: boolean; versionExistingContent?: boolean } = { path: '' }) =>
+  async (
+    command: Command,
+    options: { path?: string; override?: boolean; versionExistingContent?: boolean; format?: 'md' | 'mdx' } = {
+      path: '',
+      override: false,
+      versionExistingContent: false,
+      format: 'mdx',
+    }
+  ) =>
     writeResource(directory, { ...command }, { ...options, type: 'command' });
 
 /**
@@ -138,7 +146,11 @@ export const writeCommand =
  */
 export const writeCommandToService =
   (directory: string) =>
-  async (command: Command, service: { id: string; version?: string }, options: { path: string } = { path: '' }) => {
+  async (
+    command: Command,
+    service: { id: string; version?: string },
+    options: { path?: string; format?: 'md' | 'mdx' } = { path: '', format: 'mdx' }
+  ) => {
     const resourcePath = await getResourcePath(directory, service.id, service.version);
     if (!resourcePath) {
       throw new Error('Service not found');

--- a/src/domains.ts
+++ b/src/domains.ts
@@ -117,7 +117,15 @@ export const getDomains =
  */
 export const writeDomain =
   (directory: string) =>
-  async (domain: Domain, options: { path?: string; override?: boolean; versionExistingContent?: boolean } = { path: '' }) => {
+  async (
+    domain: Domain,
+    options: { path?: string; override?: boolean; versionExistingContent?: boolean; format?: 'md' | 'mdx' } = {
+      path: '',
+      override: false,
+      versionExistingContent: false,
+      format: 'mdx',
+    }
+  ) => {
     const resource: Domain = { ...domain };
 
     if (Array.isArray(domain.services)) {

--- a/src/events.ts
+++ b/src/events.ts
@@ -114,7 +114,11 @@ export const writeEvent =
   (directory: string) =>
   async (
     event: Event,
-    options: { path?: string; override?: boolean; versionExistingContent?: boolean } = { path: '', override: false }
+    options: { path?: string; override?: boolean; versionExistingContent?: boolean; format?: 'md' | 'mdx' } = {
+      path: '',
+      override: false,
+      format: 'mdx',
+    }
   ) =>
     writeResource(directory, { ...event }, { ...options, type: 'event' });
 /**
@@ -141,7 +145,11 @@ export const writeEvent =
  */
 export const writeEventToService =
   (directory: string) =>
-  async (event: Event, service: { id: string; version?: string }, options: { path: string } = { path: '' }) => {
+  async (
+    event: Event,
+    service: { id: string; version?: string },
+    options: { path?: string; format?: 'md' | 'mdx' } = { path: '', format: 'mdx' }
+  ) => {
     const resourcePath = await getResourcePath(directory, service.id, service.version);
     if (!resourcePath) {
       throw new Error('Service not found');

--- a/src/internal/resources.ts
+++ b/src/internal/resources.ts
@@ -46,21 +46,23 @@ export const versionResource = async (catalogDir: string, id: string) => {
 export const writeResource = async (
   catalogDir: string,
   resource: Resource,
-  options: { path?: string; type: string; override?: boolean; versionExistingContent?: boolean } = {
+  options: { path?: string; type: string; override?: boolean; versionExistingContent?: boolean; format?: 'md' | 'mdx' } = {
     path: '',
     type: '',
     override: false,
     versionExistingContent: false,
+    format: 'mdx',
   }
 ) => {
   const path = options.path || `/${resource.id}`;
   const fullPath = join(catalogDir, path);
+  const format = options.format || 'mdx';
 
   // Create directory if it doesn't exist
   fsSync.mkdirSync(fullPath, { recursive: true });
 
   // Create or get lock file path
-  const lockPath = join(fullPath, 'index.mdx');
+  const lockPath = join(fullPath, `index.${format}`);
 
   // Ensure the file exists before attempting to lock it
   if (!fsSync.existsSync(lockPath)) {

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -89,7 +89,15 @@ export const getQuery =
  */
 export const writeQuery =
   (directory: string) =>
-  async (query: Query, options: { path?: string; override?: boolean; versionExistingContent?: boolean } = { path: '' }) =>
+  async (
+    query: Query,
+    options: { path?: string; override?: boolean; versionExistingContent?: boolean; format?: 'md' | 'mdx' } = {
+      path: '',
+      override: false,
+      versionExistingContent: false,
+      format: 'mdx',
+    }
+  ) =>
     writeResource(directory, { ...query }, { ...options, type: 'query' });
 
 /**
@@ -139,7 +147,11 @@ export const getQueries =
  */
 export const writeQueryToService =
   (directory: string) =>
-  async (query: Query, service: { id: string; version?: string }, options: { path: string } = { path: '' }) => {
+  async (
+    query: Query,
+    service: { id: string; version?: string },
+    options: { path?: string; format?: 'md' | 'mdx' } = { path: '', format: 'mdx' }
+  ) => {
     const resourcePath = await getResourcePath(directory, service.id, service.version);
     if (!resourcePath) {
       throw new Error('Service not found');

--- a/src/services.ts
+++ b/src/services.ts
@@ -117,7 +117,14 @@ export const getServices =
  */
 export const writeService =
   (directory: string) =>
-  async (service: Service, options: { path?: string; override?: boolean; versionExistingContent?: boolean } = { path: '' }) => {
+  async (
+    service: Service,
+    options: { path?: string; override?: boolean; versionExistingContent?: boolean; format?: 'md' | 'mdx' } = {
+      path: '',
+      override: false,
+      format: 'mdx',
+    }
+  ) => {
     const resource: Service = { ...service };
 
     if (Array.isArray(service.sends)) {
@@ -186,7 +193,7 @@ export const writeServiceToDomain =
   async (
     service: Service,
     domain: { id: string; version?: string; direction?: string },
-    options: { path: string } = { path: '' }
+    options: { path?: string; format?: 'md' | 'mdx' } = { path: '', format: 'mdx' }
   ) => {
     let pathForService =
       domain.version && domain.version !== 'latest'

--- a/src/test/commands.test.ts
+++ b/src/test/commands.test.ts
@@ -307,6 +307,23 @@ describe('Commands SDK', () => {
       });
     });
 
+    it('writes the given command (as md) to EventCatalog if the format is md', async () => {
+      await writeCommand(
+        {
+          id: 'UpdateInventory',
+          name: 'Update Inventory',
+          version: '0.0.1',
+          summary: 'This is a summary',
+          markdown: '# Hello world',
+        },
+        { format: 'md' }
+      );
+
+      const command = await getCommand('UpdateInventory');
+
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'commands/UpdateInventory', 'index.md'))).toBe(true);
+    });
+
     it('writes the given command to EventCatalog under the correct path when a path is given', async () => {
       await writeCommand(
         {
@@ -425,6 +442,34 @@ describe('Commands SDK', () => {
 
       expect(fs.existsSync(path.join(CATALOG_PATH, 'services/Inventory/commands/UpdateInventory', 'index.mdx'))).toBe(true);
     });
+
+    it('writes a command to the given service (as md). When no version if given for the command the service is added to the latest service', async () => {
+      await writeService(
+        {
+          id: 'Inventory',
+          name: 'Inventory Service',
+          version: '0.0.1',
+          summary: 'Service that handles inventory',
+          markdown: '# Hello world',
+        },
+        { format: 'md' }
+      );
+
+      await writeCommandToService(
+        {
+          id: 'UpdateInventory',
+          name: 'Update Inventory',
+          version: '0.0.1',
+          summary: 'This is a summary',
+          markdown: '# Hello world',
+        },
+        { id: 'Inventory' },
+        { format: 'md' }
+      );
+
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'services/Inventory/commands/UpdateInventory', 'index.md'))).toBe(true);
+    });
+
     it('writes a command to the given service. When a version is given for the command the service is added to that service version', async () => {
       await writeService({
         id: 'Inventory',

--- a/src/test/domains.test.ts
+++ b/src/test/domains.test.ts
@@ -268,6 +268,21 @@ describe('Domain SDK', () => {
       });
     });
 
+    it('writes the given domain (as md) to EventCatalog and assumes the path if one if not given', async () => {
+      await writeDomain(
+        {
+          id: 'Payment',
+          name: 'Payment Domain',
+          version: '0.0.1',
+          summary: 'All things to do with the payment systems',
+          markdown: '# Hello world',
+        },
+        { format: 'md' }
+      );
+
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'domains/Payment', 'index.md'))).toBe(true);
+    });
+
     it('writes the given domain to EventCatalog under the correct path when a path is given', async () => {
       await writeDomain(
         {

--- a/src/test/events.test.ts
+++ b/src/test/events.test.ts
@@ -554,6 +554,39 @@ describe('Events SDK', () => {
       });
     });
 
+    it('writes the given event (as .md) to EventCatalog if the format is .md', async () => {
+      await writeEvent(
+        {
+          id: 'InventoryAdjusted',
+          name: 'Inventory Adjusted',
+          version: '0.0.1',
+          summary: 'This is a summary',
+          markdown: '# Hello world',
+          sidebar: {
+            badge: 'badge',
+          },
+        },
+        {
+          format: 'md',
+        }
+      );
+
+      const event = await getEvent('InventoryAdjusted');
+
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'events/InventoryAdjusted', 'index.md'))).toBe(true);
+
+      expect(event).toEqual({
+        id: 'InventoryAdjusted',
+        name: 'Inventory Adjusted',
+        version: '0.0.1',
+        summary: 'This is a summary',
+        markdown: '# Hello world',
+        sidebar: {
+          badge: 'badge',
+        },
+      });
+    });
+
     it('writes the given event to EventCatalog under the correct path when a path is given', async () => {
       await writeEvent(
         {

--- a/src/test/queries.test.ts
+++ b/src/test/queries.test.ts
@@ -565,6 +565,21 @@ describe('Queries SDK', () => {
       });
     });
 
+    it('writes the given query to EventCatalog (as md). When no version if given for the query the service is added to the latest service', async () => {
+      await writeQuery(
+        {
+          id: 'GetOrder',
+          name: 'Get Order',
+          version: '0.0.1',
+          summary: 'This is a summary',
+          markdown: '# Hello world',
+        },
+        { format: 'md' }
+      );
+
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'queries/GetOrder', 'index.md'))).toBe(true);
+    });
+
     it('writes the given query to EventCatalog under the correct path when a path is given', async () => {
       await writeQuery(
         {
@@ -712,6 +727,31 @@ describe('Queries SDK', () => {
       );
 
       expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService/queries/GetOrder', 'index.mdx'))).toBe(true);
+    });
+    it('writes an query to the given service (as md). When no version if given for the service the query is added to the latest service', async () => {
+      await writeService({
+        id: 'InventoryService',
+        name: 'Inventory Service',
+        version: '0.0.1',
+        summary: 'Service that handles inventory',
+        markdown: '# Hello world',
+      });
+
+      await writeQueryToService(
+        {
+          id: 'GetOrder',
+          name: 'Get Order',
+          version: '0.0.1',
+          summary: 'This is a summary',
+          markdown: '# Hello world',
+        },
+        {
+          id: 'InventoryService',
+        },
+        { format: 'md' }
+      );
+
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService/queries/GetOrder', 'index.md'))).toBe(true);
     });
     it('writes an query to the given service. When a version is given for the service the query is added to that service version', async () => {
       await writeService({

--- a/src/test/services.test.ts
+++ b/src/test/services.test.ts
@@ -436,6 +436,31 @@ describe('Services SDK', () => {
       });
     });
 
+    it('writes the given service (as .md) to EventCatalog if the format is .md', async () => {
+      await writeService(
+        {
+          id: 'InventoryService',
+          name: 'Inventory Service',
+          version: '0.0.1',
+          summary: 'Service tat handles the inventory',
+          markdown: '# Hello world',
+        },
+        { format: 'md' }
+      );
+
+      const service = await getService('InventoryService');
+
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService', 'index.md'))).toBe(true);
+
+      expect(service).toEqual({
+        id: 'InventoryService',
+        name: 'Inventory Service',
+        version: '0.0.1',
+        summary: 'Service tat handles the inventory',
+        markdown: '# Hello world',
+      });
+    });
+
     it('writes the given service to EventCatalog under the correct path when a path is given', async () => {
       await writeService(
         {
@@ -653,6 +678,25 @@ describe('Services SDK', () => {
 
       expect(fs.existsSync(path.join(CATALOG_PATH, 'domains/Shopping/services/InventoryService', 'index.mdx'))).toBe(true);
     });
+
+    it('writes a service to the given domain (as md). When no version if given for the domain the service is added to the latest domain', async () => {
+      await writeServiceToDomain(
+        {
+          id: 'InventoryService',
+          name: 'Inventory Service',
+          version: '0.0.1',
+          summary: 'Service tat handles the inventory',
+          markdown: '# Hello world',
+        },
+        {
+          id: 'Shopping',
+        },
+        { format: 'md' }
+      );
+
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'domains/Shopping/services/InventoryService', 'index.md'))).toBe(true);
+    });
+
     it('writes a service to the given domain. When a version is given for the domain the service is added to that domain version', async () => {
       await writeServiceToDomain(
         {


### PR DESCRIPTION
Folks are still using `md` file extensions on older version of EventCatalog. This SDK change allows them to opt into the format of the file they want to create for older versions, but also will be used for future generators, that also need to work with md files (for older versions of the catalog)