### PR TITLE
feat(sdk): added backwards compatibility for md files

### DIFF
--- a/.changeset/dry-pears-pretend.md
+++ b/.changeset/dry-pears-pretend.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/sdk": patch
+---
+
+feat(sdk): added backwards compatibility for md files

--- a/src/channels.ts
+++ b/src/channels.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs/promises';
-import { join } from 'node:path';
+import { join, extname } from 'node:path';
 import type { Channel } from './types';
-import { getResource, getResources, rmResourceById, versionResource, writeResource } from './internal/resources';
+import { getResource, getResourcePath, getResources, rmResourceById, versionResource, writeResource } from './internal/resources';
 import { findFileById } from './internal/utils';
 import { getEvent, rmEventById, writeEvent } from './events';
 import { getCommand, rmCommandById, writeCommand } from './commands';
@@ -255,6 +255,8 @@ export const addMessageToChannel =
     const { getMessage, rmMessageById, writeMessage } = functions[collection as keyof typeof functions];
 
     const message = await getMessage(directory)(_message.id, _message.version);
+    const messagePath = await getResourcePath(directory, _message.id, _message.version);
+    const extension = extname(messagePath?.fullPath || '');
 
     if (!message) throw new Error(`Message ${_message.id} with version ${_message.version} not found`);
 
@@ -276,5 +278,5 @@ export const addMessageToChannel =
     const pathToResource = join(path, collection);
 
     await rmMessageById(directory)(_message.id, _message.version, true);
-    await writeMessage(pathToResource)(message);
+    await writeMessage(pathToResource)(message, { format: extension === '.md' ? 'md' : 'mdx' });
   };

--- a/src/domains.ts
+++ b/src/domains.ts
@@ -5,6 +5,7 @@ import fsSync from 'node:fs';
 import {
   addFileToResource,
   getResource,
+  getResourcePath,
   getResources,
   rmResourceById,
   versionResource,
@@ -319,6 +320,10 @@ export const domainHasVersion = (directory: string) => async (id: string, versio
 export const addServiceToDomain =
   (directory: string) => async (id: string, service: { id: string; version: string }, version?: string) => {
     let domain: Domain = await getDomain(directory)(id, version);
+    const domainPath = await getResourcePath(directory, id, version);
+
+    // Get the extension of the file
+    const extension = path.extname(domainPath?.fullPath || '');
 
     if (domain.services === undefined) {
       domain.services = [];
@@ -334,5 +339,5 @@ export const addServiceToDomain =
     domain.services.push(service);
 
     await rmDomainById(directory)(id, version, true);
-    await writeDomain(directory)(domain);
+    await writeDomain(directory)(domain, { format: extension === '.md' ? 'md' : 'mdx' });
   };

--- a/src/services.ts
+++ b/src/services.ts
@@ -1,6 +1,6 @@
 import type { Service, Specifications } from './types';
 import fs from 'node:fs/promises';
-import { join, dirname } from 'node:path';
+import { join, dirname, extname } from 'node:path';
 import {
   addFileToResource,
   getFileFromResource,
@@ -10,6 +10,7 @@ import {
   writeResource,
   getVersionedDirectory,
   getResources,
+  getResourcePath,
 } from './internal/resources';
 import { findFileById, uniqueVersions } from './internal/utils';
 
@@ -359,6 +360,8 @@ export const getSpecificationFilesForService = (directory: string) => async (id:
 export const addMessageToService =
   (directory: string) => async (id: string, direction: string, event: { id: string; version: string }, version?: string) => {
     let service: Service = await getService(directory)(id, version);
+    const servicePath = await getResourcePath(directory, id, version);
+    const extension = extname(servicePath?.fullPath || '');
 
     if (direction === 'sends') {
       if (service.sends === undefined) {
@@ -397,7 +400,7 @@ export const addMessageToService =
     const pathToResource = join(path, 'services');
 
     await rmServiceById(directory)(id, version);
-    await writeService(pathToResource)(service);
+    await writeService(pathToResource)(service, { format: extension === '.md' ? 'md' : 'mdx' });
   };
 
 /**

--- a/src/test/domains.test.ts
+++ b/src/test/domains.test.ts
@@ -744,6 +744,37 @@ describe('Domain SDK', () => {
       expect(domain.services).toEqual([{ id: 'Order Service', version: '2.0.0' }]);
     });
 
+    it('adds a service to the domain, if the extension of the domain is `md` then the extension is maintained', async () => {
+      await writeDomain(
+        {
+          id: 'Orders',
+          name: 'Orders Domain',
+          version: '0.0.1',
+          summary: 'This is a summary',
+          markdown: '# Hello world',
+        },
+        { format: 'md' }
+      );
+
+      await addServiceToDomain('Orders', { id: 'Order Service', version: '2.0.0' });
+
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'domains/Orders', 'index.md'))).toBe(true);
+    });
+
+    it('adds a service to the domain, if the extension of the domain is `mdx (default)` then the extension is maintained', async () => {
+      await writeDomain({
+        id: 'Orders',
+        name: 'Orders Domain',
+        version: '0.0.1',
+        summary: 'This is a summary',
+        markdown: '# Hello world',
+      });
+
+      await addServiceToDomain('Orders', { id: 'Order Service', version: '2.0.0' });
+
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'domains/Orders', 'index.mdx'))).toBe(true);
+    });
+
     it('does not add a service to the domain if the service is already on the list', async () => {
       await writeDomain({
         id: 'Orders',

--- a/src/test/services.test.ts
+++ b/src/test/services.test.ts
@@ -1117,6 +1117,23 @@ describe('Services SDK', () => {
       ).rejects.toThrowError("Direction doesnotexist is invalid, only 'receives' and 'sends' are supported");
     });
 
+    it('when an event is added to the service, the extension of the service is maintained', async () => {
+      await writeService(
+        {
+          id: 'InventoryService',
+          name: 'Inventory Service',
+          version: '0.0.1',
+          summary: 'Service that handles the inventory',
+          markdown: '# Hello world',
+        },
+        { format: 'md' }
+      );
+
+      await addEventToService('InventoryService', 'sends', { id: 'InventoryUpdatedEvent', version: '2.0.0' }, '0.0.1');
+
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService', 'index.md'))).toBe(true);
+    });
+
     describe('when services are within a domain directory', () => {
       it('takes an existing event and adds it to the sends of an existing service', async () => {
         await writeServiceToDomain(


### PR DESCRIPTION
when adding services to domains, the domain file that is written extension is now persisted (md or mdx)