### PR TITLE
feat(sdk): added override flag for writing messages to services

### DIFF
--- a/.changeset/eleven-gifts-shout.md
+++ b/.changeset/eleven-gifts-shout.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/sdk": patch
+---
+
+feat(sdk): added override flag for writing messages to services

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -149,7 +149,7 @@ export const writeCommandToService =
   async (
     command: Command,
     service: { id: string; version?: string },
-    options: { path?: string; format?: 'md' | 'mdx' } = { path: '', format: 'mdx' }
+    options: { path?: string; format?: 'md' | 'mdx'; override?: boolean } = { path: '', format: 'mdx', override: false }
   ) => {
     const resourcePath = await getResourcePath(directory, service.id, service.version);
     if (!resourcePath) {

--- a/src/events.ts
+++ b/src/events.ts
@@ -148,7 +148,7 @@ export const writeEventToService =
   async (
     event: Event,
     service: { id: string; version?: string },
-    options: { path?: string; format?: 'md' | 'mdx' } = { path: '', format: 'mdx' }
+    options: { path?: string; format?: 'md' | 'mdx'; override?: boolean } = { path: '', format: 'mdx', override: false }
   ) => {
     const resourcePath = await getResourcePath(directory, service.id, service.version);
     if (!resourcePath) {

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -150,7 +150,7 @@ export const writeQueryToService =
   async (
     query: Query,
     service: { id: string; version?: string },
-    options: { path?: string; format?: 'md' | 'mdx' } = { path: '', format: 'mdx' }
+    options: { path?: string; format?: 'md' | 'mdx'; override?: boolean } = { path: '', format: 'mdx', override: false }
   ) => {
     const resourcePath = await getResourcePath(directory, service.id, service.version);
     if (!resourcePath) {

--- a/src/test/commands.test.ts
+++ b/src/test/commands.test.ts
@@ -514,6 +514,50 @@ describe('Commands SDK', () => {
       );
       expect(fs.existsSync(path.join(CATALOG_PATH, 'services/Inventory/commands/UpdateInventory', 'index.mdx'))).toBe(true);
     });
+
+    it('when override is true, it overrides the command if it already exists', async () => {
+      await writeService({
+        id: 'InventoryService',
+        name: 'Inventory Service',
+        version: '1.0.0',
+        summary: 'This is a summary',
+        markdown: '# Hello world',
+      });
+
+      // Write the first event
+      await writeCommandToService(
+        {
+          id: 'UpdateInventory',
+          name: 'Update Inventory',
+          version: '0.0.1',
+          summary: 'This is a summary',
+          markdown: '# Hello world',
+        },
+        {
+          id: 'InventoryService',
+        }
+      );
+
+      await writeCommandToService(
+        {
+          id: 'UpdateInventory',
+          name: 'Update Inventory',
+          version: '0.0.1',
+          summary: 'This is a summary',
+          markdown: 'Overridden content',
+        },
+        {
+          id: 'InventoryService',
+        },
+        {
+          override: true,
+        }
+      );
+
+      const command = await getCommand('UpdateInventory', '0.0.1');
+
+      expect(command.markdown).toBe('Overridden content');
+    });
   });
 
   describe('rmCommand', () => {

--- a/src/test/events.test.ts
+++ b/src/test/events.test.ts
@@ -820,6 +820,50 @@ describe('Events SDK', () => {
         true
       );
     });
+
+    it('when override is true, it overrides the event if it already exists', async () => {
+      await writeService({
+        id: 'InventoryService',
+        name: 'Inventory Service',
+        version: '1.0.0',
+        summary: 'This is a summary',
+        markdown: '# Hello world',
+      });
+
+      // Write the first event
+      await writeEventToService(
+        {
+          id: 'InventoryAdjusted',
+          name: 'Inventory Adjusted',
+          version: '0.0.1',
+          summary: 'This is a summary',
+          markdown: '# Hello world',
+        },
+        {
+          id: 'InventoryService',
+        }
+      );
+
+      await writeEventToService(
+        {
+          id: 'InventoryAdjusted',
+          name: 'Inventory Adjusted',
+          version: '0.0.1',
+          summary: 'This is a summary',
+          markdown: 'Overridden content',
+        },
+        {
+          id: 'InventoryService',
+        },
+        {
+          override: true,
+        }
+      );
+
+      const event = await getEvent('InventoryAdjusted', '0.0.1');
+
+      expect(event.markdown).toBe('Overridden content');
+    });
   });
 
   describe('rmEvent', () => {

--- a/src/test/queries.test.ts
+++ b/src/test/queries.test.ts
@@ -803,6 +803,50 @@ describe('Queries SDK', () => {
       );
       expect(fs.existsSync(path.join(CATALOG_PATH, 'services/InventoryService/queries/GetOrder', 'index.mdx'))).toBe(true);
     });
+
+    it('when override is true, it overrides the event if it already exists', async () => {
+      await writeService({
+        id: 'InventoryService',
+        name: 'Inventory Service',
+        version: '1.0.0',
+        summary: 'This is a summary',
+        markdown: '# Hello world',
+      });
+
+      // Write the first event
+      await writeQueryToService(
+        {
+          id: 'GetOrder',
+          name: 'Get Order',
+          version: '0.0.1',
+          summary: 'This is a summary',
+          markdown: '# Hello world',
+        },
+        {
+          id: 'InventoryService',
+        }
+      );
+
+      await writeQueryToService(
+        {
+          id: 'GetOrder',
+          name: 'Get Order',
+          version: '0.0.1',
+          summary: 'This is a summary',
+          markdown: 'Overridden content',
+        },
+        {
+          id: 'InventoryService',
+        },
+        {
+          override: true,
+        }
+      );
+
+      const query = await getQuery('GetOrder', '0.0.1');
+
+      expect(query.markdown).toBe('Overridden content');
+    });
   });
 
   describe('rmQuery', () => {


### PR DESCRIPTION
If you try and `write{Message}ToService` and the message already exists it will fail.

Added new `override` flag that lets people do this (similar to the writeEvent for example).