### PR TITLE
feat(sdk): when adding services to domains you can override the service

### DIFF
--- a/.changeset/forty-dots-refuse.md
+++ b/.changeset/forty-dots-refuse.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/sdk": patch
+---
+
+feat(sdk): when adding services to domains you can override the service

--- a/src/services.ts
+++ b/src/services.ts
@@ -194,7 +194,7 @@ export const writeServiceToDomain =
   async (
     service: Service,
     domain: { id: string; version?: string; direction?: string },
-    options: { path?: string; format?: 'md' | 'mdx' } = { path: '', format: 'mdx' }
+    options: { path?: string; format?: 'md' | 'mdx'; override?: boolean } = { path: '', format: 'mdx', override: false }
   ) => {
     let pathForService =
       domain.version && domain.version !== 'latest'

--- a/src/test/services.test.ts
+++ b/src/test/services.test.ts
@@ -731,6 +731,41 @@ describe('Services SDK', () => {
       );
       expect(fs.existsSync(path.join(CATALOG_PATH, 'domains/Shopping/services/InventoryService/', 'index.mdx'))).toBe(true);
     });
+
+    it('when override is true, it overrides the service if it already exists', async () => {
+      await writeServiceToDomain(
+        {
+          id: 'InventoryService',
+          name: 'Inventory Service',
+          version: '0.0.1',
+          summary: 'Service tat handles the inventory',
+          markdown: '# Hello world',
+        },
+        {
+          id: 'Shopping',
+        }
+      );
+
+      await writeServiceToDomain(
+        {
+          id: 'InventoryService',
+          name: 'Inventory Service',
+          version: '0.0.1',
+          summary: 'This is overridden content',
+          markdown: 'Overridden content',
+        },
+        {
+          id: 'Shopping',
+        },
+        { override: true }
+      );
+
+      const service = await getService('InventoryService', '0.0.1');
+
+      expect(service.markdown).toBe('Overridden content');
+      expect(service.summary).toBe('This is overridden content');
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'domains/Shopping/services/InventoryService', 'index.mdx'))).toBe(true);
+    });
   });
 
   describe('versionService', () => {


### PR DESCRIPTION
Added the ability to set an `override` flag for the `writeServiceToDomain` function,.