### PR TITLE
chore(sdk): sdk now formats JSON files before writing them

### DIFF
--- a/.changeset/twenty-brooms-turn.md
+++ b/.changeset/twenty-brooms-turn.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/sdk": patch
+---
+
+chore(sdk): sdk now formats JSON files before writing them

--- a/src/internal/resources.ts
+++ b/src/internal/resources.ts
@@ -196,7 +196,16 @@ export const addFileToResource = async (
 
   if (!pathToResource) throw new Error('Cannot find directory to write file to');
 
-  fsSync.writeFileSync(join(dirname(pathToResource), file.fileName), file.content);
+  let fileContent = file.content.trim();
+
+  try {
+    const json = JSON.parse(fileContent);
+    fileContent = JSON.stringify(json, null, 2);
+  } catch (error) {
+    console.error(error);
+  }
+
+  fsSync.writeFileSync(join(dirname(pathToResource), file.fileName), fileContent);
 };
 
 export const getFileFromResource = async (catalogDir: string, id: string, file: { fileName: string }, version?: string) => {

--- a/src/test/events.test.ts
+++ b/src/test/events.test.ts
@@ -1373,6 +1373,28 @@ describe('Events SDK', () => {
       expect(addSchemaToEvent('InventoryAdjusted', file)).rejects.toThrowError('Cannot find directory to write file to');
     });
 
+    it('if the file can be parsed into JSON, it will be parsed into JSON and written to the file formatted', async () => {
+      const unformattedJson = `{ "name": "John", "age": 30 }`;
+      const file = { schema: unformattedJson, fileName: 'schema.json' };
+
+      await writeEvent({
+        id: 'InventoryAdjusted',
+        name: 'Inventory Adjusted',
+        version: '0.0.1',
+        summary: 'This is a summary',
+        markdown: '# Hello world',
+      });
+
+      await addSchemaToEvent('InventoryAdjusted', file);
+
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'events/InventoryAdjusted', 'schema.json'))).toBe(true);
+      const formattedJson = fs.readFileSync(path.join(CATALOG_PATH, 'events/InventoryAdjusted', 'schema.json'), 'utf8');
+      expect(formattedJson).toBe(`{
+  "name": "John",
+  "age": 30
+}`);
+    });
+
     describe('when events are within a service directory', () => {
       it('takes a given file and writes it to the location of the given event', async () => {
         const schema = `{

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -133,6 +133,7 @@ export interface Badge {
   content: string;
   backgroundColor: string;
   textColor: string;
+  icon?: string;
 }
 
 export interface UbiquitousLanguage {


### PR DESCRIPTION
- When writing schemas to resources, if they are JSON they are now formatted before written.
- Added `icon` support for badges on SDK