### PR TITLE
feat(sdk): added ability to fetch schemas

### DIFF
--- a/.changeset/pink-cycles-grin.md
+++ b/.changeset/pink-cycles-grin.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/sdk": minor
+---
+
+feat(sdk): added ability to fetch schemas

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -29,12 +29,15 @@ import { addMessageToService } from './services';
  *
  * // Gets a version of the command
  * const command = await getCommand('UpdateInventory', '0.0.1');
+ *
+ * // Gets the command with the schema attached
+ * const command = await getCommand('UpdateInventory', '0.0.1', { attachSchema: true });
  * ```
  */
 export const getCommand =
   (directory: string) =>
-  async (id: string, version?: string): Promise<Command> =>
-    getResource(directory, id, version, { type: 'command' }) as Promise<Command>;
+  async (id: string, version?: string, options?: { attachSchema?: boolean }): Promise<Command> =>
+    getResource(directory, id, version, { type: 'command', ...options }) as Promise<Command>;
 
 /**
  * Returns all commands from EventCatalog.
@@ -52,11 +55,14 @@ export const getCommand =
  *
  * // Gets all commands (only latest version) from the catalog
  * const commands = await getCommands({ latestOnly: true });
+ *
+ * // Gets all commands with the schema attached
+ * const commands = await getCommands({ attachSchema: true });
  * ```
  */
 export const getCommands =
   (directory: string) =>
-  async (options?: { latestOnly?: boolean }): Promise<Command[]> =>
+  async (options?: { latestOnly?: boolean; attachSchema?: boolean }): Promise<Command[]> =>
     getResources(directory, { type: 'commands', ...options }) as Promise<Command[]>;
 
 /**

--- a/src/events.ts
+++ b/src/events.ts
@@ -28,12 +28,15 @@ import {
  *
  * // Gets a version of the event
  * const event = await getEvent('InventoryAdjusted', '0.0.1');
+ *
+ * // Get the event with the schema attached
+ * const event = await getEvent('InventoryAdjusted', '0.0.1', { attachSchema: true });
  * ```
  */
 export const getEvent =
   (directory: string) =>
-  async (id: string, version?: string): Promise<Event> =>
-    getResource(directory, id, version, { type: 'event' }) as Promise<Event>;
+  async (id: string, version?: string, options?: { attachSchema?: boolean }): Promise<Event> =>
+    getResource(directory, id, version, { type: 'event', ...options }) as Promise<Event>;
 
 /**
  * Returns all events from EventCatalog.
@@ -51,11 +54,14 @@ export const getEvent =
  *
  * // Gets all events (only latest version) from the catalog
  * const events = await getEvents({ latestOnly: true });
+ *
+ * // Get all events with the schema attached
+ * const events = await getEvents({ attachSchema: true });
  * ```
  */
 export const getEvents =
   (directory: string) =>
-  async (options?: { latestOnly?: boolean }): Promise<Event[]> =>
+  async (options?: { latestOnly?: boolean; attachSchema?: boolean }): Promise<Event[]> =>
     getResources(directory, { type: 'events', ...options }) as Promise<Event[]>;
 
 /**

--- a/src/queries.ts
+++ b/src/queries.ts
@@ -28,12 +28,15 @@ import {
  *
  * // Gets a version of the event
  * const event = await getQuery('GetOrder', '0.0.1');
+ *
+ * // Gets the query with the schema attached
+ * const event = await getQuery('GetOrder', '0.0.1', { attachSchema: true });
  * ```
  */
 export const getQuery =
   (directory: string) =>
-  async (id: string, version?: string): Promise<Query> =>
-    getResource(directory, id, version, { type: 'query' }) as Promise<Query>;
+  async (id: string, version?: string, options?: { attachSchema?: boolean }): Promise<Query> =>
+    getResource(directory, id, version, { type: 'query', ...options }) as Promise<Query>;
 
 /**
  * Write a query to EventCatalog.
@@ -116,11 +119,14 @@ export const writeQuery =
  *
  * // Gets all queries (only latest version) from the catalog
  * const queries = await getQueries({ latestOnly: true });
+ *
+ * // Gets all queries with the schema attached
+ * const queries = await getQueries({ attachSchema: true });
  * ```
  */
 export const getQueries =
   (directory: string) =>
-  async (options?: { latestOnly?: boolean }): Promise<Query[]> =>
+  async (options?: { latestOnly?: boolean; attachSchema?: boolean }): Promise<Query[]> =>
     getResources(directory, { type: 'queries', ...options }) as Promise<Query[]>;
 
 /**

--- a/src/test/commands.test.ts
+++ b/src/test/commands.test.ts
@@ -132,6 +132,56 @@ describe('Commands SDK', () => {
       });
     });
 
+    it('returns the command with the schema attached when the attachSchema option is set to true', async () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+        },
+      };
+
+      await writeCommand({
+        id: 'UpdateInventory',
+        name: 'Update Inventory',
+        version: '0.0.1',
+        summary: 'This is a summary',
+        markdown: '# Hello world',
+        schemaPath: 'schema.json',
+      });
+
+      const file = { schema: JSON.stringify(schema), fileName: 'schema.json' };
+
+      await addSchemaToCommand('UpdateInventory', file);
+
+      const test = await getCommand('UpdateInventory', '0.0.1', { attachSchema: true });
+
+      expect(test.schema).toEqual(schema);
+    });
+
+    it('does not attach the schema if the attachSchema option is set to false', async () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+        },
+      };
+
+      const file = { schema: JSON.stringify(schema), fileName: 'schema.json' };
+
+      await writeCommand({
+        id: 'UpdateInventory',
+        name: 'Update Inventory',
+        version: '0.0.1',
+        schemaPath: 'schema.json',
+        summary: 'This is a summary',
+        markdown: '# Hello world',
+      });
+
+      const test = await getCommand('UpdateInventory', '0.0.1', { attachSchema: false });
+
+      expect(test.schema).toBeUndefined();
+    });
+
     it('returns undefined if the command is not found', async () => {
       await expect(await getCommand('UpdateInventory')).toBe(undefined);
     });
@@ -281,6 +331,32 @@ describe('Commands SDK', () => {
       );
 
       expect(commands.length).toBe(2);
+    });
+
+    it('returns the commands with the schema attached when the attachSchema option is set to true', async () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+        },
+      };
+
+      const file = { schema: JSON.stringify(schema), fileName: 'schema.json' };
+
+      await writeCommand({
+        id: 'UpdateInventory',
+        name: 'Update Inventory',
+        version: '0.0.1',
+        summary: 'This is a summary',
+        markdown: '# Hello world',
+        schemaPath: 'schema.json',
+      });
+
+      await addSchemaToCommand('UpdateInventory', file);
+
+      const commands = await getCommands({ attachSchema: true });
+
+      expect(commands[0].schema).toEqual(schema);
     });
   });
 

--- a/src/test/events.test.ts
+++ b/src/test/events.test.ts
@@ -146,6 +146,58 @@ describe('Events SDK', () => {
       });
     });
 
+    it('returns the event with the schema attached when the attachSchema option is set to true', async () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+        },
+      };
+
+      await writeEvent({
+        id: 'InventoryAdjusted',
+        name: 'Inventory Adjusted',
+        version: '0.0.1',
+        schemaPath: 'schema.json',
+        summary: 'This is a summary',
+        markdown: '# Hello world',
+      });
+
+      const file = { schema: JSON.stringify(schema), fileName: 'schema.json' };
+
+      await addSchemaToEvent('InventoryAdjusted', file);
+
+      const test = await getEvent('InventoryAdjusted', '0.0.1', { attachSchema: true });
+
+      expect(test.schema).toEqual(schema);
+    });
+
+    it('does not attach the schema if the attachSchema option is not set', async () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+        },
+      };
+
+      const file = { schema: JSON.stringify(schema), fileName: 'schema.json' };
+
+      await writeEvent({
+        id: 'InventoryAdjusted2',
+        name: 'Inventory Adjusted',
+        version: '0.0.1',
+        schemaPath: 'schema.json',
+        summary: 'This is a summary',
+        markdown: '# Hello world',
+      });
+
+      await addSchemaToEvent('InventoryAdjusted2', file);
+
+      const test = await getEvent('InventoryAdjusted2', '0.0.1', { attachSchema: false });
+
+      expect(test.schema).toEqual(undefined);
+    });
+
     it('returns undefined when a given resource is not found', async () => {
       const event = await getEvent('InventoryAdjusted');
       await expect(event).toEqual(undefined);
@@ -522,6 +574,31 @@ describe('Events SDK', () => {
           },
         ])
       );
+    });
+    it('returns the event with the schema attached when the attachSchema option is set to true', async () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+        },
+      };
+
+      await writeEvent({
+        id: 'InventoryAdjusted',
+        name: 'Inventory Adjusted',
+        version: '0.0.1',
+        schemaPath: 'schema.json',
+        summary: 'This is a summary',
+        markdown: '# Hello world',
+      });
+
+      const file = { schema: JSON.stringify(schema), fileName: 'schema.json' };
+
+      await addSchemaToEvent('InventoryAdjusted', file);
+
+      const test = await getEvent('InventoryAdjusted', '0.0.1', { attachSchema: true });
+
+      expect(test.schema).toEqual(schema);
     });
   });
 

--- a/src/test/queries.test.ts
+++ b/src/test/queries.test.ts
@@ -147,6 +147,58 @@ describe('Queries SDK', () => {
       });
     });
 
+    it('returns the query with the schema attached when the attachSchema option is set to true', async () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+        },
+      };
+
+      const file = { schema: JSON.stringify(schema), fileName: 'schema.json' };
+
+      await writeQuery({
+        id: 'GetOrder',
+        name: 'Get Order',
+        version: '0.0.1',
+        summary: 'This is a summary',
+        markdown: '# Hello world',
+        schemaPath: 'schema.json',
+      });
+
+      await addSchemaToQuery('GetOrder', file);
+
+      const test = await getQuery('GetOrder', '0.0.1', { attachSchema: true });
+
+      expect(test.schema).toEqual(schema);
+    });
+
+    it('does not attach the schema if the attachSchema option is set to false', async () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+        },
+      };
+
+      const file = { schema: JSON.stringify(schema), fileName: 'schema.json' };
+
+      await writeQuery({
+        id: 'GetOrder2',
+        name: 'Get Order',
+        version: '0.0.1',
+        summary: 'This is a summary',
+        markdown: '# Hello world',
+        schemaPath: 'schema.json',
+      });
+
+      await addSchemaToQuery('GetOrder2', file);
+
+      const test = await getQuery('GetOrder2', '0.0.1', { attachSchema: false });
+
+      expect(test.schema).toEqual(undefined);
+    });
+
     it('returns undefined when a given resource is not found', async () => {
       const query = await getQuery('GetOrder');
       await expect(query).toEqual(undefined);
@@ -539,6 +591,31 @@ describe('Queries SDK', () => {
           },
         ])
       );
+    });
+    it('returns the queries with the schema attached when the attachSchema option is set to true', async () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+        },
+      };
+
+      const file = { schema: JSON.stringify(schema), fileName: 'schema.json' };
+
+      await writeQuery({
+        id: 'GetOrder',
+        name: 'Get Order',
+        version: '0.0.1',
+        summary: 'This is a summary',
+        markdown: '# Hello world',
+        schemaPath: 'schema.json',
+      });
+
+      await addSchemaToQuery('GetOrder', file);
+
+      const test = await getQueries({ attachSchema: true });
+
+      expect(test[0].schema).toEqual(schema);
     });
   });
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -28,6 +28,9 @@ export interface BaseSchema {
       label?: string;
     };
   };
+
+  // SDK types
+  schema?: any;
 }
 
 export type ResourcePointer = {


### PR DESCRIPTION
Added new option to fetch schemas through get functions for all messages.

when `attachSchema` is set to true, the schema will be hydrated with the fetched resource.