### PR TITLE
fix(sdk): searching resources by id now escapes special characters

### DIFF
--- a/.changeset/silly-buses-kiss.md
+++ b/.changeset/silly-buses-kiss.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/sdk": patch
+---
+
+fix(sdk): searching resources by id now escapes special characters

--- a/src/events.ts
+++ b/src/events.ts
@@ -261,7 +261,7 @@ export const addFileToEvent =
  * ```ts
  * import utils from '@eventcatalog/utils';
  *
- * const { addSchemaToEvent } = utils('/path/to/eventcatalog');
+ * const { addFileToEvent } = utils('/path/to/eventcatalog');
  *
  * // JSON schema example
  * const schema = {
@@ -278,11 +278,11 @@ export const addFileToEvent =
  *  "required": ["name", "age"]
  * };
  *
- * // adds a schema to the latest InventoryAdjusted event
- * await addSchemaToEvent('InventoryAdjusted', { schema, fileName: 'schema.json' });
+ * // adds a file to the latest InventoryAdjusted event
+ * await addFileToEvent('InventoryAdjusted', { schema, fileName: 'schema.json' });
  *
  * // adds a file to a specific version of the InventoryAdjusted event
- * await addSchemaToEvent('InventoryAdjusted', { schema, fileName: 'schema.json' }, '0.0.1');
+ * await addFileToEvent('InventoryAdjusted', { schema, fileName: 'schema.json' }, '0.0.1');
  *
  * ```
  */

--- a/src/internal/utils.ts
+++ b/src/internal/utils.ts
@@ -105,7 +105,10 @@ export const readMdxFile = async (path: string) => {
 };
 
 export const searchFilesForId = async (files: string[], id: string, version?: string) => {
-  const idRegex = new RegExp(`^id:\\s*(['"]|>-)?\\s*${id}['"]?\\s*$`, 'm');
+  // Escape the id to avoid regex issues
+  const escapedId = id.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const idRegex = new RegExp(`^id:\\s*(['"]|>-)?\\s*${escapedId}['"]?\\s*$`, 'm');
+
   const versionRegex = new RegExp(`^version:\\s*['"]?${version}['"]?\\s*$`, 'm');
 
   const matches = files.map((file) => {

--- a/src/test/events.test.ts
+++ b/src/test/events.test.ts
@@ -1498,6 +1498,32 @@ describe('Events SDK', () => {
 }`);
     });
 
+    it('if the id of the event has a $ value in the id, the schema is still added to the event', async () => {
+      const { getEvent } = utils(CATALOG_PATH);
+
+      const schema = `{
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        }
+      }`;
+      const file = { schema, fileName: 'schema.json' };
+
+      await writeEvent({
+        id: 'Inventory$Adjusted$1',
+        name: 'Inventory Adjusted',
+        version: '0.0.1',
+        summary: 'This is a summary',
+        markdown: '# Hello world',
+      });
+
+      const event = await getEvent('Inventory$Adjusted$1');
+
+      await addSchemaToEvent(event.id, file);
+      expect(fs.existsSync(path.join(CATALOG_PATH, 'events/Inventory$Adjusted$1', 'schema.json'))).toBe(true);
+    });
     describe('when events are within a service directory', () => {
       it('takes a given file and writes it to the location of the given event', async () => {
         const schema = `{


### PR DESCRIPTION
When we try and find a resource by id we now escape special characters for example getting an id by "ThisIs$MYEventName" works.

Related issue: https://github.com/event-catalog/generators/issues/113