### PR TITLE
feat(sdk): added new functions for messages

### DIFF
--- a/src/docs.ts
+++ b/src/docs.ts
@@ -35,3 +35,4 @@ export * from './custom-docs';
 export * from './teams';
 export * from './users';
 export * from './eventcatalog';
+export * from './messages';

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,6 +75,8 @@ import {
   addMessageToChannel,
 } from './channels';
 
+import { getMessageBySchemaPath, getProducersAndConsumersForMessage } from './messages';
+
 import { getResourcePath } from './internal/resources';
 
 import { writeCustomDoc, getCustomDoc, getCustomDocs, rmCustomDoc } from './custom-docs';
@@ -808,5 +810,27 @@ export default (path: string) => {
      * Returns the path to a given resource by id and version
      */
     getResourcePath: getResourcePath,
+
+    /**
+     * ================================
+     *            General Message Utils
+     * ================================
+     */
+
+    /**
+     * Returns a message from EventCatalog by a given schema path.
+     *
+     * @param path - The path to the message to retrieve
+     * @returns Message|Undefined
+     */
+    getMessageBySchemaPath: getMessageBySchemaPath(join(path)),
+
+    /**
+     * Returns the producers and consumers (services) for a given message
+     * @param id - The id of the message to get the producers and consumers for
+     * @param version - Optional version of the message
+     * @returns { producers: Service[], consumers: Service[] }
+     */
+    getProducersAndConsumersForMessage: getProducersAndConsumersForMessage(join(path)),
   };
 };

--- a/src/internal/resources.ts
+++ b/src/internal/resources.ts
@@ -256,3 +256,12 @@ export const getFileFromResource = async (catalogDir: string, id: string, file: 
 export const getVersionedDirectory = (sourceDirectory: string, version: any): string => {
   return join(sourceDirectory, 'versioned', version);
 };
+
+export const isLatestVersion = async (catalogDir: string, id: string, version?: string) => {
+  const resource = await getResource(catalogDir, id, version);
+  if (!resource) return false;
+
+  const pathToResource = await getResourcePath(catalogDir, id, version);
+
+  return !pathToResource?.relativePath.replace(/\\/g, '/').includes('/versioned/');
+};

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -1,0 +1,113 @@
+import { dirname, join } from 'node:path';
+import type { Message, Service } from './types';
+import matter from 'gray-matter';
+import { getResource, getResourcePath, isLatestVersion } from './internal/resources';
+import { getFiles } from './internal/utils';
+import { getServices } from './services';
+
+/**
+ * Returns a message from EventCatalog by a given schema path.
+ *
+ * @example
+ * ```ts
+ * import utils from '@eventcatalog/utils';
+ *
+ * const { getMessageBySchemaPath } = utils('/path/to/eventcatalog');
+ *
+ * // Get the message by the schema path
+ * const message = await getMessageBySchemaPath('/path/to/eventcatalog/messages/InventoryAdjusted/schema.json');
+ * const message = await getMessageBySchemaPath('/path/to/eventcatalog/messages/InventoryAdjusted/schema.avro');
+ * ```
+ */
+export const getMessageBySchemaPath =
+  (directory: string) =>
+  async (path: string, options?: { attachSchema?: boolean }): Promise<Message> => {
+    const pathToMessage = dirname(path);
+    try {
+      const files = await getFiles(`${pathToMessage}/index.{md,mdx}`);
+
+      if (!files || files.length === 0) {
+        throw new Error(`No message definition file (index.md or index.mdx) found in directory: ${pathToMessage}`);
+      }
+      const messageFile = files[0];
+
+      const { data } = matter.read(messageFile);
+      const { id, version } = data;
+
+      if (!id || !version) {
+        throw new Error(`Message definition file at ${messageFile} is missing 'id' or 'version' in its frontmatter.`);
+      }
+
+      const message = await getResource(directory, id, version, { type: 'message', ...options });
+
+      if (!message) {
+        throw new Error(`Message resource with id '${id}' and version '${version}' not found, as referenced in ${messageFile}.`);
+      }
+      return message as Message;
+    } catch (error) {
+      console.error(`Failed to get message for schema path ${path}. Error processing directory ${pathToMessage}:`, error);
+      if (error instanceof Error) {
+        // Prepend more context to the existing error message
+        error.message = `Failed to retrieve message from ${pathToMessage}: ${error.message}`;
+        throw error;
+      }
+      throw new Error(`Failed to retrieve message from ${pathToMessage} due to an unknown error.`);
+    }
+  };
+
+/**
+ * Returns the producers and consumers (services) for a given message.
+ *
+ * @example
+ * ```ts
+ * import utils from '@eventcatalog/utils';
+ *
+ * const { getProducersAndConsumersForMessage } = utils('/path/to/eventcatalog');
+ *
+ * // Returns the producers and consumers (services) for a given message
+ * const { producers, consumers } = await getProducersAndConsumersForMessage('InventoryAdjusted', '0.0.1');
+ */
+export const getProducersAndConsumersForMessage =
+  (directory: string) =>
+  async (id: string, version?: string): Promise<{ producers: Service[]; consumers: Service[] }> => {
+    const services = await getServices(directory)({ latestOnly: true });
+    const message = (await getResource(directory, id, version, { type: 'message' })) as Message;
+    const isMessageLatestVersion = await isLatestVersion(directory, id, version);
+
+    if (!message) {
+      throw new Error(`Message resource with id '${id}' and version '${version}' not found.`);
+    }
+
+    const producers: Service[] = [];
+    const consumers: Service[] = [];
+
+    for (const service of services) {
+      const servicePublishesMessage = service.sends?.some((_message) => {
+        if (_message.version) {
+          return _message.id === message.id && _message.version === message.version;
+        }
+        if (isMessageLatestVersion && _message.id === message.id) {
+          return true;
+        }
+        return false;
+      });
+      const serviceSubscribesToMessage = service.receives?.some((_message) => {
+        if (_message.version) {
+          return _message.id === message.id && _message.version === message.version;
+        }
+        if (isMessageLatestVersion && _message.id === message.id) {
+          return true;
+        }
+        return false;
+      });
+
+      if (servicePublishesMessage) {
+        producers.push(service);
+      }
+      if (serviceSubscribesToMessage) {
+        consumers.push(service);
+      }
+    }
+
+    return { producers, consumers };
+  };

--- a/src/test/messages.test.ts
+++ b/src/test/messages.test.ts
@@ -1,0 +1,239 @@
+import { expect, it, describe, beforeEach, afterEach } from 'vitest';
+import utils from '../index';
+import path from 'node:path';
+import fs from 'node:fs';
+
+const CATALOG_PATH = path.join(__dirname, 'catalog-events');
+
+const {
+  getMessageBySchemaPath,
+  writeEvent,
+  addSchemaToEvent,
+  getProducersAndConsumersForMessage,
+  writeService,
+  addEventToService,
+  versionEvent,
+} = utils(CATALOG_PATH);
+
+// clean the catalog before each test
+beforeEach(() => {
+  fs.rmSync(CATALOG_PATH, { recursive: true, force: true });
+  fs.mkdirSync(CATALOG_PATH, { recursive: true });
+});
+
+afterEach(() => {
+  fs.rmSync(CATALOG_PATH, { recursive: true, force: true });
+});
+
+describe('Messages SDK', () => {
+  describe('getMessageBySchemaPath', () => {
+    it('returns a message from the given schema path to the message,', async () => {
+      await writeEvent({
+        id: 'InventoryAdjusted',
+        name: 'Inventory Adjusted',
+        version: '0.0.1',
+        summary: 'This is a summary',
+        markdown: '# Hello world',
+      });
+
+      const schema = `{
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        }
+      }`;
+
+      await addSchemaToEvent('InventoryAdjusted', { schema, fileName: 'schema.json' });
+
+      const test = await getMessageBySchemaPath(path.join(CATALOG_PATH, 'events/InventoryAdjusted/schema.json'));
+
+      expect(test).toEqual({
+        id: 'InventoryAdjusted',
+        name: 'Inventory Adjusted',
+        version: '0.0.1',
+        summary: 'This is a summary',
+        markdown: '# Hello world',
+      });
+    });
+    it('throws an error when the message is not found', async () => {
+      await expect(getMessageBySchemaPath(path.join(CATALOG_PATH, 'events/InventoryAdjusted/schema.json'))).rejects.toThrow(
+        'Failed to retrieve message from /Users/dboyne/dev/eventcatalog/sdk/src/test/catalog-events/events/InventoryAdjusted: No message definition file (index.md or index.mdx) found in directory: /Users/dboyne/dev/eventcatalog/sdk/src/test/catalog-events/events/InventoryAdjusted'
+      );
+    });
+  });
+
+  describe('getProducersAndConsumersForMessage', () => {
+    it('returns the producers and consumers for a given message', async () => {
+      await writeEvent({
+        id: 'InventoryAdjusted',
+        name: 'Inventory Adjusted',
+        version: '0.0.1',
+        summary: 'This is a summary',
+        markdown: '# Hello world',
+      });
+
+      await writeService({
+        id: 'InventoryService',
+        name: 'Inventory Service',
+        version: '0.0.1',
+        summary: 'This is a summary',
+        markdown: '# Hello world',
+      });
+
+      await writeService({
+        id: 'OrderService',
+        name: 'Order Service',
+        version: '0.0.1',
+        summary: 'This is a summary',
+        markdown: '# Hello world',
+      });
+
+      await addEventToService('InventoryService', 'sends', { id: 'InventoryAdjusted', version: '0.0.1' }, '0.0.1');
+      await addEventToService('OrderService', 'receives', { id: 'InventoryAdjusted', version: '0.0.1' }, '0.0.1');
+
+      const { producers, consumers } = await getProducersAndConsumersForMessage('InventoryAdjusted', '0.0.1');
+
+      expect(producers).toEqual([
+        {
+          id: 'InventoryService',
+          name: 'Inventory Service',
+          version: '0.0.1',
+          summary: 'This is a summary',
+          markdown: '# Hello world',
+          sends: [
+            {
+              id: 'InventoryAdjusted',
+              version: '0.0.1',
+            },
+          ],
+        },
+      ]);
+      expect(consumers).toEqual([
+        {
+          id: 'OrderService',
+          name: 'Order Service',
+          version: '0.0.1',
+          summary: 'This is a summary',
+          markdown: '# Hello world',
+          receives: [
+            {
+              id: 'InventoryAdjusted',
+              version: '0.0.1',
+            },
+          ],
+        },
+      ]);
+    });
+
+    it('when the service sends a message, but the version is not specified and the message is the latest version, it should be added to the sends of the service', async () => {
+      await writeEvent({
+        id: 'InventoryAdjusted',
+        name: 'Inventory Adjusted',
+        version: '0.0.1',
+        summary: 'This is a summary',
+        markdown: '# Hello world',
+      });
+
+      await writeService({
+        id: 'InventoryService',
+        name: 'Inventory Service',
+        version: '0.0.1',
+        summary: 'This is a summary',
+        markdown: '# Hello world',
+        sends: [
+          {
+            id: 'InventoryAdjusted',
+          },
+        ],
+      });
+
+      const { producers } = await getProducersAndConsumersForMessage('InventoryAdjusted', '0.0.1');
+
+      expect(producers).toEqual([
+        {
+          id: 'InventoryService',
+          name: 'Inventory Service',
+          version: '0.0.1',
+          sends: [
+            {
+              id: 'InventoryAdjusted',
+            },
+          ],
+          markdown: '# Hello world',
+          summary: 'This is a summary',
+        },
+      ]);
+    });
+
+    it('when the service receives a message, but the version is not specified and the message is the latest version, it should be added to the receives of the service', async () => {
+      await writeEvent({
+        id: 'InventoryAdjusted',
+        name: 'Inventory Adjusted',
+        version: '0.0.1',
+        summary: 'This is a summary',
+        markdown: '# Hello world',
+      });
+
+      await writeService({
+        id: 'InventoryService',
+        name: 'Inventory Service',
+        version: '0.0.1',
+        summary: 'This is a summary',
+        markdown: '# Hello world',
+        receives: [
+          {
+            id: 'InventoryAdjusted',
+          },
+        ],
+      });
+
+      const { consumers } = await getProducersAndConsumersForMessage('InventoryAdjusted', '0.0.1');
+
+      expect(consumers).toEqual([
+        {
+          id: 'InventoryService',
+          name: 'Inventory Service',
+          version: '0.0.1',
+          receives: [
+            {
+              id: 'InventoryAdjusted',
+            },
+          ],
+          markdown: '# Hello world',
+          summary: 'This is a summary',
+        },
+      ]);
+    });
+
+    it('when the service sends a message, but the version is not specified and the message is not the latest version, it should not be added to the sends of the service', async () => {
+      await writeEvent({
+        id: 'InventoryAdjusted',
+        name: 'Inventory Adjusted',
+        version: '0.0.1',
+        summary: 'This is a summary',
+        markdown: '# Hello world',
+      });
+
+      await versionEvent('InventoryAdjusted');
+
+      await writeService({
+        id: 'InventoryService',
+        name: 'Inventory Service',
+        version: '0.0.1',
+        summary: 'This is a summary',
+        markdown: '# Hello world',
+        sends: [
+          {
+            id: 'InventoryAdjusted',
+          },
+        ],
+      });
+
+      const { producers } = await getProducersAndConsumersForMessage('InventoryAdjusted', '0.0.1');
+
+      expect(producers).toEqual([]);
+    });
+  });
+});

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -35,7 +35,7 @@ export interface BaseSchema {
 
 export type ResourcePointer = {
   id: string;
-  version: string;
+  version?: string;
   type?: string;
 };
 
@@ -51,7 +51,7 @@ export interface ChannelPointer extends ResourcePointer {
   parameters?: Record<string, string>;
 }
 
-export type Message = Event | Command;
+export type Message = Event | Command | Query;
 
 enum ResourceType {
   Service = 'service',


### PR DESCRIPTION
Added new SDK functions

- `getProducersAndConsumersForMessage`
     - Returns the producers and consumers (services) for a given message
- `getMessageBySchemaPath`
     - Returns a a message by it's schema path  