### PR TITLE
fix(sdk): getting messages by path now uses catalog directory

### DIFF
--- a/.changeset/rare-llamas-serve.md
+++ b/.changeset/rare-llamas-serve.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/sdk": patch
+---
+
+fix(sdk): getting messages by path now uses catalog directory

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -24,7 +24,7 @@ export const getMessageBySchemaPath =
   async (path: string, options?: { attachSchema?: boolean }): Promise<Message> => {
     const pathToMessage = dirname(path);
     try {
-      const files = await getFiles(`${pathToMessage}/index.{md,mdx}`);
+      const files = await getFiles(`${directory}/${pathToMessage}/index.{md,mdx}`);
 
       if (!files || files.length === 0) {
         throw new Error(`No message definition file (index.md or index.mdx) found in directory: ${pathToMessage}`);

--- a/src/test/messages.test.ts
+++ b/src/test/messages.test.ts
@@ -47,7 +47,7 @@ describe('Messages SDK', () => {
 
       await addSchemaToEvent('InventoryAdjusted', { schema, fileName: 'schema.json' });
 
-      const test = await getMessageBySchemaPath(path.join(CATALOG_PATH, 'events/InventoryAdjusted/schema.json'));
+      const test = await getMessageBySchemaPath('events/InventoryAdjusted/schema.json');
 
       expect(test).toEqual({
         id: 'InventoryAdjusted',


### PR DESCRIPTION
Fixed an issue with the function to get messages by the schema directory. The EventCatalog directory is now appended to the path.