### PR TITLE
Uses regex to split folder paths

### DIFF
--- a/.changeset/funny-peaches-think.md
+++ b/.changeset/funny-peaches-think.md
@@ -1,0 +1,5 @@
+---
+'@eventcatalog/sdk': patch
+---
+
+Updates the string search split for forward or backward path separators

--- a/.changeset/pink-mangos-think.md
+++ b/.changeset/pink-mangos-think.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/sdk": patch
+---
+
+fix(sdk): fixed issue with broken path seperators for windows/linux

--- a/src/channels.ts
+++ b/src/channels.ts
@@ -274,7 +274,7 @@ export const addMessageToChannel =
       throw new Error(`Cannot find message ${id} in the catalog`);
     }
 
-    const path = existingResource.split(`/${collection}`)[0];
+    const path = existingResource.split(`/[\\/]+${collection}/`)[0];
     const pathToResource = join(path, collection);
 
     await rmMessageById(directory)(_message.id, _message.version, true);

--- a/src/channels.ts
+++ b/src/channels.ts
@@ -274,7 +274,7 @@ export const addMessageToChannel =
       throw new Error(`Cannot find message ${id} in the catalog`);
     }
 
-    const path = existingResource.split(`/[\\/]+${collection}/`)[0];
+    const path = existingResource.split(`/[\\/]+${collection}`)[0];
     const pathToResource = join(path, collection);
 
     await rmMessageById(directory)(_message.id, _message.version, true);

--- a/src/services.ts
+++ b/src/services.ts
@@ -396,7 +396,7 @@ export const addMessageToService =
     }
 
     // Get where the service was located, make sure it goes back there.
-    const path = existingResource.split('/services')[0];
+    const path = existingResource.split(/[\\/]+services/)[0];
     const pathToResource = join(path, 'services');
 
     await rmServiceById(directory)(id, version);

--- a/src/test/channels.test.ts
+++ b/src/test/channels.test.ts
@@ -698,6 +698,28 @@ describe('Channels SDK', () => {
         expect(fs.existsSync(path.join(CATALOG_PATH, 'events/InventoryCreated', 'test.txt'))).toBe(true);
       });
 
+      it('the folder location of the event does not change when adding a message to the event', async () => {
+        await writeChannel(mockChannel);
+        await writeEvent({
+          id: 'InventoryCreated',
+          name: 'Inventory Created',
+          version: '0.0.1',
+          summary: 'This is a summary',
+          markdown: '# Hello world',
+        });
+
+        await addEventToChannel('inventory.{env}.events', {
+          id: 'InventoryCreated',
+          version: '0.0.1',
+          parameters: {
+            env: 'dev',
+          },
+        });
+
+        const pathToEvent = path.join(CATALOG_PATH, 'events', 'InventoryCreated');
+        expect(fs.existsSync(pathToEvent)).toEqual(true);
+      });
+
       it('throws an error when message cannot be found', async () => {
         await writeChannel(mockChannel);
 

--- a/src/test/services.test.ts
+++ b/src/test/services.test.ts
@@ -1704,4 +1704,58 @@ describe('Services SDK', () => {
       });
     });
   });
+
+  describe('addMessageToService (addEventToService)', () => {
+    it('adds the given message to the service', async () => {
+      await writeService({
+        id: 'InventoryService',
+        name: 'Inventory Service',
+        version: '0.0.1',
+        summary: 'Service that handles the inventory',
+        markdown: '# Hello world',
+      });
+
+      await writeEvent({
+        id: 'InventoryAdjusted',
+        name: 'Inventory Adjusted',
+        version: '0.0.1',
+        summary: 'This is a summary',
+        markdown: '# Hello world',
+      });
+
+      await addEventToService('InventoryService', 'sends', { id: 'InventoryAdjusted', version: '0.0.1' }, '0.0.1');
+
+      const service = await getService('InventoryService');
+
+      expect(service.sends).toEqual([
+        {
+          id: 'InventoryAdjusted',
+          version: '0.0.1',
+        },
+      ]);
+    });
+
+    it('the folder location of the service does not change when adding a message to the service', async () => {
+      await writeService({
+        id: 'InventoryService',
+        name: 'Inventory Service',
+        version: '0.0.1',
+        summary: 'Service that handles the inventory',
+        markdown: '# Hello world',
+      });
+
+      await writeEvent({
+        id: 'InventoryAdjusted',
+        name: 'Inventory Adjusted',
+        version: '0.0.1',
+        summary: 'This is a summary',
+        markdown: '# Hello world',
+      });
+
+      await addEventToService('InventoryService', 'sends', { id: 'InventoryAdjusted', version: '0.0.1' }, '0.0.1');
+
+      const pathToService = path.join(CATALOG_PATH, 'services', 'InventoryService');
+      expect(fs.existsSync(pathToService)).toEqual(true);
+    });
+  });
 });


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to EventCatalog here: https://www.eventcatalog.dev/docs/contributing/overview

Happy contributing!

-->

## Motivation

My motivation is to help make the SDK work on Windows. The path split assumed forward path separators. This should make it agnostic to forward or backward path separators.
