### PR TITLE
feat: add diagrams collection support to SDK

### DIFF
--- a/.changeset/tiny-ears-accept.md
+++ b/.changeset/tiny-ears-accept.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/sdk": patch
+---
+
+feat: add diagrams collection support to SDK

--- a/src/cli-docs.ts
+++ b/src/cli-docs.ts
@@ -1458,6 +1458,109 @@ export const cliFunctions: CLIFunctionDoc[] = [
   },
 
   // ================================
+  //            Diagrams
+  // ================================
+  {
+    name: 'getDiagram',
+    description: 'Returns a diagram from EventCatalog by its ID',
+    category: 'Diagrams',
+    args: [
+      { name: 'id', type: 'string', required: true, description: 'The ID of the diagram to retrieve' },
+      { name: 'version', type: 'string', required: false, description: 'Specific version to retrieve' },
+    ],
+    examples: [
+      { description: 'Get the latest diagram', command: 'npx @eventcatalog/sdk getDiagram "ArchitectureDiagram"' },
+      { description: 'Get a specific version', command: 'npx @eventcatalog/sdk getDiagram "ArchitectureDiagram" "1.0.0"' },
+    ],
+  },
+  {
+    name: 'getDiagrams',
+    description: 'Returns all diagrams from EventCatalog',
+    category: 'Diagrams',
+    args: [{ name: 'options', type: 'json', required: false, description: 'Options: {latestOnly?}' }],
+    examples: [
+      { description: 'Get all diagrams', command: 'npx @eventcatalog/sdk getDiagrams' },
+      { description: 'Get only latest versions', command: 'npx @eventcatalog/sdk getDiagrams \'{"latestOnly":true}\'' },
+    ],
+  },
+  {
+    name: 'writeDiagram',
+    description: 'Writes a diagram to EventCatalog',
+    category: 'Diagrams',
+    args: [
+      {
+        name: 'diagram',
+        type: 'json',
+        required: true,
+        description: 'Diagram object with id, name, version, and markdown',
+      },
+      { name: 'options', type: 'json', required: false, description: 'Options: {path?, override?, versionExistingContent?}' },
+    ],
+    examples: [
+      {
+        description: 'Write a new diagram',
+        command:
+          'npx @eventcatalog/sdk writeDiagram \'{"id":"ArchitectureDiagram","name":"Architecture Diagram","version":"1.0.0","markdown":"# Architecture Diagram"}\'',
+      },
+    ],
+  },
+  {
+    name: 'rmDiagram',
+    description: 'Removes a diagram by its path',
+    category: 'Diagrams',
+    args: [{ name: 'path', type: 'string', required: true, description: 'Path to the diagram' }],
+    examples: [{ description: 'Remove a diagram', command: 'npx @eventcatalog/sdk rmDiagram "/ArchitectureDiagram"' }],
+  },
+  {
+    name: 'rmDiagramById',
+    description: 'Removes a diagram by its ID',
+    category: 'Diagrams',
+    args: [
+      { name: 'id', type: 'string', required: true, description: 'The ID of the diagram to remove' },
+      { name: 'version', type: 'string', required: false, description: 'Specific version to remove' },
+    ],
+    examples: [{ description: 'Remove a diagram', command: 'npx @eventcatalog/sdk rmDiagramById "ArchitectureDiagram"' }],
+  },
+  {
+    name: 'versionDiagram',
+    description: 'Moves the current diagram to a versioned directory',
+    category: 'Diagrams',
+    args: [{ name: 'id', type: 'string', required: true, description: 'The ID of the diagram to version' }],
+    examples: [{ description: 'Version a diagram', command: 'npx @eventcatalog/sdk versionDiagram "ArchitectureDiagram"' }],
+  },
+  {
+    name: 'addFileToDiagram',
+    description: 'Adds a file to a diagram',
+    category: 'Diagrams',
+    args: [
+      { name: 'id', type: 'string', required: true, description: 'The ID of the diagram' },
+      { name: 'file', type: 'json', required: true, description: 'File object: {content, fileName}' },
+      { name: 'version', type: 'string', required: false, description: 'Specific version' },
+    ],
+    examples: [
+      {
+        description: 'Add a file to a diagram',
+        command: 'npx @eventcatalog/sdk addFileToDiagram "ArchitectureDiagram" \'{"content":"...","fileName":"diagram.png"}\'',
+      },
+    ],
+  },
+  {
+    name: 'diagramHasVersion',
+    description: 'Checks if a specific version of a diagram exists',
+    category: 'Diagrams',
+    args: [
+      { name: 'id', type: 'string', required: true, description: 'The ID of the diagram' },
+      { name: 'version', type: 'string', required: true, description: 'Version to check' },
+    ],
+    examples: [
+      {
+        description: 'Check if version exists',
+        command: 'npx @eventcatalog/sdk diagramHasVersion "ArchitectureDiagram" "1.0.0"',
+      },
+    ],
+  },
+
+  // ================================
   //            Messages
   // ================================
   {

--- a/src/diagrams.ts
+++ b/src/diagrams.ts
@@ -1,0 +1,220 @@
+import fs from 'node:fs/promises';
+import { join } from 'node:path';
+import { findFileById } from './internal/utils';
+import type { Diagram } from './types';
+import { getResource, getResources, rmResourceById, versionResource, writeResource, addFileToResource } from './internal/resources';
+
+/**
+ * Returns a diagram from EventCatalog.
+ *
+ * You can optionally specify a version to get a specific version of the diagram
+ *
+ * @example
+ * ```ts
+ * import utils from '@eventcatalog/utils';
+ *
+ * const { getDiagram } = utils('/path/to/eventcatalog');
+ *
+ * // Gets the latest version of the diagram
+ * const diagram = await getDiagram('ArchitectureDiagram');
+ *
+ * // Gets a version of the diagram
+ * const diagram = await getDiagram('ArchitectureDiagram', '0.0.1');
+ *
+ * ```
+ */
+export const getDiagram =
+  (directory: string) =>
+  async (id: string, version?: string): Promise<Diagram> =>
+    getResource(directory, id, version, { type: 'diagram' }) as Promise<Diagram>;
+
+/**
+ * Returns all diagrams from EventCatalog.
+ *
+ * You can optionally specify if you want to get the latest version of the diagrams.
+ *
+ * @example
+ * ```ts
+ * import utils from '@eventcatalog/utils';
+ *
+ * const { getDiagrams } = utils('/path/to/eventcatalog');
+ *
+ * // Gets all diagrams (and versions) from the catalog
+ * const diagrams = await getDiagrams();
+ *
+ * // Gets all diagrams (only latest version) from the catalog
+ * const diagrams = await getDiagrams({ latestOnly: true });
+ *
+ * ```
+ */
+export const getDiagrams =
+  (directory: string) =>
+  async (options?: { latestOnly?: boolean }): Promise<Diagram[]> =>
+    getResources(directory, { type: 'diagrams', latestOnly: options?.latestOnly }) as Promise<Diagram[]>;
+
+/**
+ * Write a diagram to EventCatalog.
+ *
+ * You can optionally override the path of the diagram.
+ *
+ * @example
+ * ```ts
+ * import utils from '@eventcatalog/utils';
+ *
+ * const { writeDiagram } = utils('/path/to/eventcatalog');
+ *
+ * // Write a diagram to the catalog
+ * // Diagram would be written to diagrams/ArchitectureDiagram
+ * await writeDiagram({
+ *   id: 'ArchitectureDiagram',
+ *   name: 'Architecture Diagram',
+ *   version: '0.0.1',
+ *   summary: 'Architecture diagram',
+ *   markdown: '# Architecture Diagram',
+ * });
+ *
+ * // Write a diagram to the catalog but override the path
+ * // Diagram would be written to diagrams/System/ArchitectureDiagram
+ * await writeDiagram({
+ *    id: 'ArchitectureDiagram',
+ *    name: 'Architecture Diagram',
+ *    version: '0.0.1',
+ *    summary: 'Architecture diagram',
+ *    markdown: '# Architecture Diagram',
+ * }, { path: "/System/ArchitectureDiagram"});
+ *
+ * // Write a diagram to the catalog and override the existing content (if there is any)
+ * await writeDiagram({
+ *    id: 'ArchitectureDiagram',
+ *    name: 'Architecture Diagram',
+ *    version: '0.0.1',
+ *    summary: 'Architecture diagram',
+ *    markdown: '# Architecture Diagram',
+ * }, { override: true });
+ *
+ * // Write a diagram to the catalog and version the previous version
+ * // only works if the new version is greater than the previous version
+ * await writeDiagram({
+ *    id: 'ArchitectureDiagram',
+ *    name: 'Architecture Diagram',
+ *    version: '0.0.1',
+ *    summary: 'Architecture diagram',
+ *    markdown: '# Architecture Diagram',
+ * }, { versionExistingContent: true });
+ *
+ * ```
+ */
+export const writeDiagram =
+  (directory: string) =>
+  async (
+    diagram: Diagram,
+    options: { path?: string; override?: boolean; versionExistingContent?: boolean; format?: 'md' | 'mdx' } = {
+      path: '',
+      override: false,
+      format: 'mdx',
+    }
+  ) =>
+    writeResource(directory, { ...diagram }, { ...options, type: 'diagram' });
+
+/**
+ * Delete a diagram at its given path.
+ *
+ * @example
+ * ```ts
+ * import utils from '@eventcatalog/utils';
+ *
+ * const { rmDiagram } = utils('/path/to/eventcatalog');
+ *
+ * // removes a diagram at the given path (diagrams dir is appended to the given path)
+ * // Removes the diagram at diagrams/ArchitectureDiagram
+ * await rmDiagram('/ArchitectureDiagram');
+ * ```
+ */
+export const rmDiagram = (directory: string) => async (path: string) => {
+  await fs.rm(join(directory, path), { recursive: true });
+};
+
+/**
+ * Delete a diagram by its id.
+ *
+ * Optionally specify a version to delete a specific version of the diagram.
+ *
+ * @example
+ * ```ts
+ * import utils from '@eventcatalog/utils';
+ *
+ * const { rmDiagramById } = utils('/path/to/eventcatalog');
+ *
+ * // deletes the latest ArchitectureDiagram diagram
+ * await rmDiagramById('ArchitectureDiagram');
+ *
+ * // deletes a specific version of the ArchitectureDiagram diagram
+ * await rmDiagramById('ArchitectureDiagram', '0.0.1');
+ * ```
+ */
+export const rmDiagramById = (directory: string) => async (id: string, version?: string, persistFiles?: boolean) => {
+  await rmResourceById(directory, id, version, { type: 'diagram', persistFiles });
+};
+
+/**
+ * Version a diagram by its id.
+ *
+ * Takes the latest diagram and moves it to a versioned directory.
+ * All files with this diagram are also versioned (e.g /diagrams/ArchitectureDiagram/diagram.png)
+ *
+ * @example
+ * ```ts
+ * import utils from '@eventcatalog/utils';
+ *
+ * const { versionDiagram } = utils('/path/to/eventcatalog');
+ *
+ * // moves the latest ArchitectureDiagram diagram to a versioned directory
+ * // the version within that diagram is used as the version number.
+ * await versionDiagram('ArchitectureDiagram');
+ *
+ * ```
+ */
+export const versionDiagram = (directory: string) => async (id: string) => versionResource(directory, id);
+
+/**
+ * Check to see if the catalog has a version for the given diagram.
+ *
+ * @example
+ * ```ts
+ * import utils from '@eventcatalog/utils';
+ *
+ * const { diagramHasVersion } = utils('/path/to/eventcatalog');
+ *
+ * // returns true if version is found for the given diagram and version (supports semver)
+ * await diagramHasVersion('ArchitectureDiagram', '0.0.1');
+ * await diagramHasVersion('ArchitectureDiagram', 'latest');
+ * await diagramHasVersion('ArchitectureDiagram', '0.0.x');
+ *
+ * ```
+ */
+export const diagramHasVersion = (directory: string) => async (id: string, version?: string) => {
+  const file = await findFileById(directory, id, version);
+  return !!file;
+};
+
+/**
+ * Adds a file to the given diagram.
+ *
+ * @example
+ * ```ts
+ * import utils from '@eventcatalog/utils';
+ *
+ * const { addFileToDiagram } = utils('/path/to/eventcatalog');
+ *
+ * // adds a file to the diagram
+ * await addFileToDiagram('ArchitectureDiagram', { content: '...', fileName: 'diagram.png' });
+ *
+ * // adds a file to a specific version of the diagram
+ * await addFileToDiagram('ArchitectureDiagram', { content: '...', fileName: 'diagram.png' }, '0.0.1');
+ *
+ * ```
+ */
+export const addFileToDiagram =
+  (directory: string) =>
+  async (id: string, file: { content: string; fileName: string }, version?: string): Promise<void> =>
+    addFileToResource(directory, id, file, version, { type: 'diagram' });

--- a/src/diagrams.ts
+++ b/src/diagrams.ts
@@ -2,7 +2,14 @@ import fs from 'node:fs/promises';
 import { join } from 'node:path';
 import { findFileById } from './internal/utils';
 import type { Diagram } from './types';
-import { getResource, getResources, rmResourceById, versionResource, writeResource, addFileToResource } from './internal/resources';
+import {
+  getResource,
+  getResources,
+  rmResourceById,
+  versionResource,
+  writeResource,
+  addFileToResource,
+} from './internal/resources';
 
 /**
  * Returns a diagram from EventCatalog.

--- a/src/docs.ts
+++ b/src/docs.ts
@@ -39,3 +39,4 @@ export * from './messages';
 export * from './entities';
 export * from './data-stores';
 export * from './data-products';
+export * from './diagrams';

--- a/src/index.ts
+++ b/src/index.ts
@@ -124,6 +124,17 @@ import {
   addFileToDataProduct,
 } from './data-products';
 
+import {
+  getDiagram,
+  getDiagrams,
+  writeDiagram,
+  rmDiagram,
+  rmDiagramById,
+  versionDiagram,
+  diagramHasVersion,
+  addFileToDiagram,
+} from './diagrams';
+
 // Export the types
 export type * from './types';
 
@@ -1238,5 +1249,67 @@ export default (path: string) => {
      * @returns
      */
     addDataProductToDomain: addDataProductToDomain(join(path, 'domains')),
+
+    /**
+     * ================================
+     *            Diagrams
+     * ================================
+     */
+
+    /**
+     * Returns a diagram from EventCatalog
+     * @param id - The id of the diagram to retrieve
+     * @param version - Optional id of the version to get (supports semver)
+     * @returns Diagram|Undefined
+     */
+    getDiagram: getDiagram(join(path)),
+    /**
+     * Returns all diagrams from EventCatalog
+     * @param latestOnly - optional boolean, set to true to get only latest versions
+     * @returns Diagram[]|Undefined
+     */
+    getDiagrams: getDiagrams(join(path)),
+    /**
+     * Adds a diagram to EventCatalog
+     *
+     * @param diagram - The diagram to write
+     * @param options - Optional options to write the diagram
+     *
+     */
+    writeDiagram: writeDiagram(join(path, 'diagrams')),
+    /**
+     * Remove a diagram from EventCatalog (modeled on the standard POSIX rm utility)
+     *
+     * @param path - The path to your diagram, e.g. `/ArchitectureDiagram`
+     *
+     */
+    rmDiagram: rmDiagram(join(path, 'diagrams')),
+    /**
+     * Remove a diagram by a diagram id
+     *
+     * @param id - The id of the diagram you want to remove
+     *
+     */
+    rmDiagramById: rmDiagramById(join(path)),
+    /**
+     * Moves a given diagram id to the version directory
+     * @param id - The id of the diagram to version
+     */
+    versionDiagram: versionDiagram(join(path)),
+    /**
+     * Check to see if a diagram version exists
+     * @param id - The id of the diagram
+     * @param version - The version of the diagram (supports semver)
+     * @returns
+     */
+    diagramHasVersion: diagramHasVersion(join(path)),
+    /**
+     * Adds a file to the given diagram
+     * @param id - The id of the diagram to add the file to
+     * @param file - File contents to add including the content and the file name
+     * @param version - Optional version of the diagram to add the file to
+     * @returns
+     */
+    addFileToDiagram: addFileToDiagram(join(path)),
   };
 };

--- a/src/test/diagrams.test.ts
+++ b/src/test/diagrams.test.ts
@@ -1,0 +1,354 @@
+// sum.test.js
+import { expect, it, describe, beforeEach, afterEach } from 'vitest';
+import utils from '../index';
+import path from 'node:path';
+import fs from 'node:fs';
+
+const CATALOG_PATH = path.join(__dirname, 'catalog-diagrams');
+
+const { writeDiagram, getDiagram, getDiagrams, rmDiagram, rmDiagramById, versionDiagram, diagramHasVersion, addFileToDiagram } =
+  utils(CATALOG_PATH);
+
+// clean the catalog before each test
+beforeEach(() => {
+  fs.rmSync(CATALOG_PATH, { recursive: true, force: true });
+  fs.mkdirSync(CATALOG_PATH, { recursive: true });
+});
+
+afterEach(() => {
+  fs.rmSync(CATALOG_PATH, { recursive: true, force: true });
+});
+
+describe('Diagrams SDK', () => {
+  describe('getDiagram', () => {
+    it('returns the given diagram id from EventCatalog and the latest version when no version is given,', async () => {
+      await writeDiagram({
+        id: 'ArchitectureDiagram',
+        name: 'Architecture Diagram',
+        version: '0.0.1',
+        summary: 'System architecture diagram',
+        markdown: '# Architecture Diagram',
+        attachments: ['https://example.com/diagram.png'],
+      });
+
+      const test = await getDiagram('ArchitectureDiagram');
+
+      expect(test).toEqual({
+        id: 'ArchitectureDiagram',
+        name: 'Architecture Diagram',
+        version: '0.0.1',
+        summary: 'System architecture diagram',
+        markdown: '# Architecture Diagram',
+        attachments: ['https://example.com/diagram.png'],
+      });
+    });
+
+    it('returns the given diagram id from EventCatalog and the requested version when a version is given,', async () => {
+      await writeDiagram({
+        id: 'ArchitectureDiagram',
+        name: 'Architecture Diagram',
+        version: '0.0.1',
+        summary: 'System architecture diagram',
+        markdown: '# Architecture Diagram',
+      });
+
+      await versionDiagram('ArchitectureDiagram');
+
+      await writeDiagram({
+        id: 'ArchitectureDiagram',
+        name: 'Architecture Diagram',
+        version: '0.0.2',
+        summary: 'System architecture diagram v2',
+        markdown: '# Architecture Diagram v2',
+      });
+
+      const test = await getDiagram('ArchitectureDiagram', '0.0.1');
+
+      expect(test).toEqual({
+        id: 'ArchitectureDiagram',
+        name: 'Architecture Diagram',
+        version: '0.0.1',
+        summary: 'System architecture diagram',
+        markdown: '# Architecture Diagram',
+      });
+    });
+
+    it('returns undefined when a given resource is not found', async () => {
+      const diagram = await getDiagram('NonExistentDiagram');
+      await expect(diagram).toEqual(undefined);
+    });
+  });
+
+  describe('getDiagrams', () => {
+    it('returns all diagrams from the catalog', async () => {
+      await writeDiagram({
+        id: 'ArchitectureDiagram',
+        name: 'Architecture Diagram',
+        version: '0.0.1',
+        summary: 'System architecture diagram',
+        markdown: '# Architecture Diagram',
+      });
+
+      await writeDiagram({
+        id: 'DataFlowDiagram',
+        name: 'Data Flow Diagram',
+        version: '0.0.1',
+        summary: 'Data flow diagram',
+        markdown: '# Data Flow Diagram',
+      });
+
+      const diagrams = await getDiagrams();
+      expect(diagrams).toHaveLength(2);
+      expect(diagrams.map((d) => d.id).sort()).toEqual(['ArchitectureDiagram', 'DataFlowDiagram']);
+    });
+
+    it('returns only latest versions when latestOnly is true', async () => {
+      await writeDiagram({
+        id: 'ArchitectureDiagram',
+        name: 'Architecture Diagram',
+        version: '0.0.1',
+        summary: 'System architecture diagram',
+        markdown: '# Architecture Diagram',
+      });
+
+      await versionDiagram('ArchitectureDiagram');
+
+      await writeDiagram({
+        id: 'ArchitectureDiagram',
+        name: 'Architecture Diagram',
+        version: '0.0.2',
+        summary: 'System architecture diagram v2',
+        markdown: '# Architecture Diagram v2',
+      });
+
+      const diagrams = await getDiagrams({ latestOnly: true });
+      expect(diagrams).toHaveLength(1);
+      expect(diagrams[0].version).toBe('0.0.2');
+    });
+  });
+
+  describe('writeDiagram', () => {
+    it('writes the given diagram to the file system', async () => {
+      await writeDiagram({
+        id: 'ArchitectureDiagram',
+        name: 'Architecture Diagram',
+        version: '0.0.1',
+        summary: 'System architecture diagram',
+        markdown: '# Architecture Diagram',
+        owners: ['team-a'],
+        badges: [{ content: 'stable', backgroundColor: 'green', textColor: 'white' }],
+      });
+
+      const diagram = await getDiagram('ArchitectureDiagram');
+
+      expect(diagram).toEqual({
+        id: 'ArchitectureDiagram',
+        name: 'Architecture Diagram',
+        version: '0.0.1',
+        summary: 'System architecture diagram',
+        markdown: '# Architecture Diagram',
+        owners: ['team-a'],
+        badges: [{ content: 'stable', backgroundColor: 'green', textColor: 'white' }],
+      });
+    });
+
+    it('writes the diagram to a custom path when path is provided', async () => {
+      await writeDiagram(
+        {
+          id: 'ArchitectureDiagram',
+          name: 'Architecture Diagram',
+          version: '0.0.1',
+          summary: 'System architecture diagram',
+          markdown: '# Architecture Diagram',
+        },
+        { path: '/System/ArchitectureDiagram' }
+      );
+
+      const diagram = await getDiagram('ArchitectureDiagram');
+      expect(diagram).toEqual({
+        id: 'ArchitectureDiagram',
+        name: 'Architecture Diagram',
+        version: '0.0.1',
+        summary: 'System architecture diagram',
+        markdown: '# Architecture Diagram',
+      });
+    });
+  });
+
+  describe('rmDiagram', () => {
+    it('removes a diagram by its path', async () => {
+      await writeDiagram({
+        id: 'ArchitectureDiagram',
+        name: 'Architecture Diagram',
+        version: '0.0.1',
+        summary: 'System architecture diagram',
+        markdown: '# Architecture Diagram',
+      });
+
+      await rmDiagram('/ArchitectureDiagram');
+
+      const diagram = await getDiagram('ArchitectureDiagram');
+
+      await expect(diagram).toEqual(undefined);
+    });
+  });
+
+  describe('rmDiagramById', () => {
+    it('removes a diagram by its id', async () => {
+      await writeDiagram({
+        id: 'ArchitectureDiagram',
+        name: 'Architecture Diagram',
+        version: '0.0.1',
+        summary: 'System architecture diagram',
+        markdown: '# Architecture Diagram',
+      });
+
+      await rmDiagramById('ArchitectureDiagram');
+
+      const diagram = await getDiagram('ArchitectureDiagram');
+
+      await expect(diagram).toEqual(undefined);
+    });
+
+    it('removes a specific version of a diagram by its id and version', async () => {
+      await writeDiagram({
+        id: 'ArchitectureDiagram',
+        name: 'Architecture Diagram',
+        version: '0.0.1',
+        summary: 'System architecture diagram',
+        markdown: '# Architecture Diagram',
+      });
+
+      await versionDiagram('ArchitectureDiagram');
+
+      await writeDiagram({
+        id: 'ArchitectureDiagram',
+        name: 'Architecture Diagram',
+        version: '0.0.2',
+        summary: 'System architecture diagram v2',
+        markdown: '# Architecture Diagram v2',
+      });
+
+      await rmDiagramById('ArchitectureDiagram', '0.0.1');
+
+      const oldDiagram = await getDiagram('ArchitectureDiagram', '0.0.1');
+      expect(oldDiagram).toEqual(undefined);
+
+      const newDiagram = await getDiagram('ArchitectureDiagram', '0.0.2');
+      expect(newDiagram).toEqual({
+        id: 'ArchitectureDiagram',
+        name: 'Architecture Diagram',
+        version: '0.0.2',
+        summary: 'System architecture diagram v2',
+        markdown: '# Architecture Diagram v2',
+      });
+    });
+  });
+
+  describe('versionDiagram', () => {
+    it('versions a diagram by moving it to a versioned directory', async () => {
+      await writeDiagram({
+        id: 'ArchitectureDiagram',
+        name: 'Architecture Diagram',
+        version: '0.0.1',
+        summary: 'System architecture diagram',
+        markdown: '# Architecture Diagram',
+      });
+
+      await versionDiagram('ArchitectureDiagram');
+
+      const versionedDiagram = await getDiagram('ArchitectureDiagram', '0.0.1');
+      expect(versionedDiagram).toEqual({
+        id: 'ArchitectureDiagram',
+        name: 'Architecture Diagram',
+        version: '0.0.1',
+        summary: 'System architecture diagram',
+        markdown: '# Architecture Diagram',
+      });
+    });
+  });
+
+  describe('diagramHasVersion', () => {
+    it('returns true if diagram version exists', async () => {
+      await writeDiagram({
+        id: 'ArchitectureDiagram',
+        name: 'Architecture Diagram',
+        version: '0.0.1',
+        summary: 'System architecture diagram',
+        markdown: '# Architecture Diagram',
+      });
+
+      const hasVersion = await diagramHasVersion('ArchitectureDiagram', '0.0.1');
+      expect(hasVersion).toBe(true);
+    });
+
+    it('returns false if diagram version does not exist', async () => {
+      await writeDiagram({
+        id: 'ArchitectureDiagram',
+        name: 'Architecture Diagram',
+        version: '0.0.1',
+        summary: 'System architecture diagram',
+        markdown: '# Architecture Diagram',
+      });
+
+      const hasVersion = await diagramHasVersion('ArchitectureDiagram', '0.0.2');
+      expect(hasVersion).toBe(false);
+    });
+
+    it('returns false if diagram does not exist', async () => {
+      const hasVersion = await diagramHasVersion('NonExistentDiagram', '0.0.1');
+      expect(hasVersion).toBe(false);
+    });
+  });
+
+  describe('addFileToDiagram', () => {
+    it('adds a file to the diagram', async () => {
+      await writeDiagram({
+        id: 'ArchitectureDiagram',
+        name: 'Architecture Diagram',
+        version: '0.0.1',
+        summary: 'System architecture diagram',
+        markdown: '# Architecture Diagram',
+      });
+
+      await addFileToDiagram('ArchitectureDiagram', { content: 'test content', fileName: 'diagram.svg' });
+
+      const diagramPath = path.join(CATALOG_PATH, 'diagrams', 'ArchitectureDiagram', 'diagram.svg');
+      expect(fs.existsSync(diagramPath)).toBe(true);
+      expect(fs.readFileSync(diagramPath, 'utf-8')).toBe('test content');
+    });
+
+    it('adds a file to a specific version of the diagram', async () => {
+      await writeDiagram({
+        id: 'ArchitectureDiagram',
+        name: 'Architecture Diagram',
+        version: '0.0.1',
+        summary: 'System architecture diagram',
+        markdown: '# Architecture Diagram',
+      });
+
+      await versionDiagram('ArchitectureDiagram');
+
+      await writeDiagram({
+        id: 'ArchitectureDiagram',
+        name: 'Architecture Diagram',
+        version: '0.0.2',
+        summary: 'System architecture diagram v2',
+        markdown: '# Architecture Diagram v2',
+      });
+
+      await addFileToDiagram('ArchitectureDiagram', { content: 'test content v1', fileName: 'diagram.svg' }, '0.0.1');
+
+      const versionedPath = path.join(
+        CATALOG_PATH,
+        'diagrams',
+        'ArchitectureDiagram',
+        'versioned',
+        '0.0.1',
+        'diagram.svg'
+      );
+      expect(fs.existsSync(versionedPath)).toBe(true);
+      expect(fs.readFileSync(versionedPath, 'utf-8')).toBe('test content v1');
+    });
+  });
+});

--- a/src/test/diagrams.test.ts
+++ b/src/test/diagrams.test.ts
@@ -339,14 +339,7 @@ describe('Diagrams SDK', () => {
 
       await addFileToDiagram('ArchitectureDiagram', { content: 'test content v1', fileName: 'diagram.svg' }, '0.0.1');
 
-      const versionedPath = path.join(
-        CATALOG_PATH,
-        'diagrams',
-        'ArchitectureDiagram',
-        'versioned',
-        '0.0.1',
-        'diagram.svg'
-      );
+      const versionedPath = path.join(CATALOG_PATH, 'diagrams', 'ArchitectureDiagram', 'versioned', '0.0.1', 'diagram.svg');
       expect(fs.existsSync(versionedPath)).toBe(true);
       expect(fs.readFileSync(versionedPath, 'utf-8')).toBe('test content v1');
     });

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -268,6 +268,15 @@ export interface Entity extends BaseSchema {
   };
 }
 
+export interface Diagram extends BaseSchema {
+  detailsPanel?: {
+    versions?: DetailPanelProperty;
+    owners?: DetailPanelProperty;
+    changelog?: DetailPanelProperty;
+    attachments?: DetailPanelProperty;
+  };
+}
+
 export type DataProductOutputPointer = {
   id: string;
   version?: string;


### PR DESCRIPTION
## Summary
- Add full CRUD support for the new `diagrams` collection following existing SDK patterns
- Includes 8 new functions: `getDiagram`, `getDiagrams`, `writeDiagram`, `rmDiagram`, `rmDiagramById`, `versionDiagram`, `diagramHasVersion`, `addFileToDiagram`
- Added `Diagram` interface to types extending `BaseSchema`
- Added CLI documentation for all diagram functions

## Test plan
- [x] All 16 new diagram tests pass
- [x] All 510 existing tests continue to pass
- [x] TypeScript build succeeds
- [x] Follows existing SDK patterns (entities, data-stores, data-products)

🤖 Generated with [Claude Code](https://claude.com/claude-code)